### PR TITLE
feat: add Pi harness adapter

### DIFF
--- a/cmd/mindwalk/main.go
+++ b/cmd/mindwalk/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/cosmtrek/mindwalk/internal/adapter"
 	"github.com/cosmtrek/mindwalk/internal/adapter/claudecode"
 	"github.com/cosmtrek/mindwalk/internal/adapter/codex"
+	"github.com/cosmtrek/mindwalk/internal/adapter/pi"
 	"github.com/cosmtrek/mindwalk/internal/citymap"
 	"github.com/cosmtrek/mindwalk/internal/model"
 	"github.com/cosmtrek/mindwalk/internal/server"
@@ -50,12 +51,13 @@ func serve(args []string) error {
 	port := fs.Int("port", 0, "port to bind on 127.0.0.1")
 	claudeDir := fs.String("claude-dir", claudecode.DefaultDir(), "Claude Code projects directory")
 	codexDir := fs.String("codex-dir", codex.DefaultDir(), "Codex sessions directory")
+	piDir := fs.String("pi-dir", pi.DefaultDir(), "Pi sessions directory")
 	dev := fs.Bool("dev", false, "prefer web/dist from the working tree")
 	noOpen := fs.Bool("no-open", false, "serve without opening a browser")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
-	return server.New(server.Config{Port: *port, ClaudeDir: *claudeDir, CodexDir: *codexDir, Dev: *dev}).Start(!*noOpen)
+	return server.New(server.Config{Port: *port, ClaudeDir: *claudeDir, CodexDir: *codexDir, PiDir: *piDir, Dev: *dev}).Start(!*noOpen)
 }
 
 func open(args []string) error {
@@ -63,6 +65,7 @@ func open(args []string) error {
 	port := fs.Int("port", 0, "port to bind on 127.0.0.1")
 	claudeDir := fs.String("claude-dir", claudecode.DefaultDir(), "Claude Code projects directory")
 	codexDir := fs.String("codex-dir", codex.DefaultDir(), "Codex sessions directory")
+	piDir := fs.String("pi-dir", pi.DefaultDir(), "Pi sessions directory")
 	noOpen := fs.Bool("no-open", false, "serve without opening a browser")
 	if err := fs.Parse(args); err != nil {
 		return err
@@ -74,7 +77,7 @@ func open(args []string) error {
 	if err != nil {
 		return err
 	}
-	return server.New(server.Config{Port: *port, ClaudeDir: *claudeDir, CodexDir: *codexDir, OpenSession: session}).Start(!*noOpen)
+	return server.New(server.Config{Port: *port, ClaudeDir: *claudeDir, CodexDir: *codexDir, PiDir: *piDir, OpenSession: session}).Start(!*noOpen)
 }
 
 func openMap(args []string) error {
@@ -127,7 +130,7 @@ func trace(args []string) error {
 
 func parseTrace(path string) (*model.Trace, error) {
 	var lastErr error
-	for _, source := range []adapter.Source{claudecode.Adapter{}, codex.Adapter{}} {
+	for _, source := range []adapter.Source{pi.Adapter{}, claudecode.Adapter{}, codex.Adapter{}} {
 		trace, err := source.Parse(path)
 		if err == nil {
 			return trace, nil
@@ -180,8 +183,8 @@ func usage() {
 
 Usage:
   mindwalk                        serve on a random local port and open the UI
-  mindwalk serve [--port N] [--no-open] [--claude-dir DIR] [--codex-dir DIR]
-  mindwalk open [--no-open] <session.jsonl> open a specific Claude Code or Codex session
+  mindwalk serve [--port N] [--no-open] [--claude-dir DIR] [--codex-dir DIR] [--pi-dir DIR]
+  mindwalk open [--no-open] <session.jsonl> open a specific Claude Code, Codex, or Pi session
   mindwalk map [--no-open] <repo>  open the repository citymap with no session
   mindwalk build <repo> [-o out]  write citymap.json
   mindwalk trace <session> [-o out] write trace.json`)

--- a/internal/adapter/pi/adapter.go
+++ b/internal/adapter/pi/adapter.go
@@ -1,0 +1,344 @@
+package pi
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/cosmtrek/mindwalk/internal/adapter"
+	"github.com/cosmtrek/mindwalk/internal/model"
+)
+
+type Adapter struct {
+	Dir string
+}
+
+func DefaultDir() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".pi", "agent", "sessions")
+}
+
+func (a Adapter) Harness() string {
+	return "pi"
+}
+
+func (a Adapter) SessionDir() string {
+	if a.Dir != "" {
+		return a.Dir
+	}
+	return DefaultDir()
+}
+
+func (a Adapter) ListSessions() ([]model.SessionMeta, error) {
+	dir := a.SessionDir()
+	if info, err := os.Stat(dir); err != nil || !info.IsDir() {
+		return nil, nil
+	}
+
+	var metas []model.SessionMeta
+	err := filepath.WalkDir(dir, func(path string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return nil
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		if filepath.Ext(path) != ".jsonl" {
+			return nil
+		}
+		meta, err := a.Summarize(path)
+		if err == nil {
+			metas = append(metas, meta)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	sort.Slice(metas, func(i, j int) bool {
+		return metas[i].EndedAt > metas[j].EndedAt
+	})
+	return metas, nil
+}
+
+func (a Adapter) Summarize(path string) (model.SessionMeta, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return model.SessionMeta{}, err
+	}
+	defer f.Close()
+
+	id := strings.TrimSuffix(filepath.Base(path), filepath.Ext(path))
+	meta := model.SessionMeta{
+		Key:     adapter.SessionKey(a.Harness(), path),
+		ID:      id,
+		Harness: a.Harness(),
+		Path:    path,
+	}
+	sawSession := false
+	seenCalls := map[string]bool{}
+
+	err = adapter.ReadJSONLines(f, func(data []byte) {
+		var line rawLine
+		if json.Unmarshal(data, &line) != nil {
+			return
+		}
+		if line.Timestamp != "" {
+			if meta.StartedAt == "" {
+				meta.StartedAt = line.Timestamp
+			}
+			meta.EndedAt = line.Timestamp
+		}
+		switch line.Type {
+		case "session":
+			sawSession = true
+			if line.ID != "" {
+				meta.ID = line.ID
+			}
+			if line.Cwd != "" && meta.Cwd == "" {
+				meta.Cwd = line.Cwd
+			}
+		case "model_change":
+			if meta.Model == "" && line.ModelID != "" {
+				meta.Model = line.ModelID
+			}
+		case "message":
+			msg := line.Message
+			if msg == nil {
+				return
+			}
+			if msg.Role == "assistant" {
+				for _, item := range msg.Content {
+					if item.Type == "toolCall" && item.ID != "" {
+						if !seenCalls[item.ID] {
+							seenCalls[item.ID] = true
+							meta.EventCount++
+						}
+					}
+				}
+			}
+		}
+	})
+	if meta.Title == "" {
+		meta.Title = filepath.Base(path)
+	}
+	if !sawSession {
+		return model.SessionMeta{}, fmt.Errorf("not a Pi session: %s", path)
+	}
+	return meta, err
+}
+
+func (a Adapter) Parse(path string) (*model.Trace, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	id := strings.TrimSuffix(filepath.Base(path), filepath.Ext(path))
+	trace := &model.Trace{
+		Version: 1,
+		Session: model.TraceSession{
+			ID:      id,
+			Harness: a.Harness(),
+			Path:    path,
+		},
+		Events: []model.Event{},
+		Marks:  []model.Mark{},
+	}
+
+	sawSession := false
+	calls := map[string]adapter.ToolCall{}
+	callOrder := []string{}
+	results := map[string]adapter.ToolResult{}
+
+	err = adapter.ReadJSONLines(f, func(data []byte) {
+		var line rawLine
+		if json.Unmarshal(data, &line) != nil {
+			return
+		}
+		if line.Timestamp != "" {
+			applyLineTime(trace, line.Timestamp)
+		}
+		switch line.Type {
+		case "session":
+			sawSession = true
+			if line.ID != "" {
+				trace.Session.ID = line.ID
+			}
+			if line.Cwd != "" {
+				trace.Session.Cwd = line.Cwd
+			}
+		case "model_change":
+			if trace.Session.Model == "" && line.ModelID != "" {
+				trace.Session.Model = line.ModelID
+			}
+		case "message":
+			msg := line.Message
+			if msg == nil {
+				return
+			}
+			switch msg.Role {
+			case "user":
+				trace.Marks = append(trace.Marks, model.Mark{
+					Seq:  len(callOrder),
+					Type: "user-message",
+				})
+			case "assistant":
+				for _, item := range msg.Content {
+					if item.Type == "toolCall" {
+						call := adapter.ToolCall{
+							ID:        item.ID,
+							Name:      normalizeToolName(item.Name),
+							Input:     normalizeInput(item.Name, item.Arguments),
+							Timestamp: line.Timestamp,
+						}
+						if _, exists := calls[call.ID]; exists {
+							return
+						}
+						calls[call.ID] = call
+						callOrder = append(callOrder, call.ID)
+					}
+				}
+			case "toolResult":
+				result := adapter.ToolResult{
+					Content: contentItemsToString(msg.Content),
+					IsError: msg.IsError,
+				}
+				if msg.ToolCallID != "" {
+					if _, exists := results[msg.ToolCallID]; exists {
+						return
+					}
+					results[msg.ToolCallID] = result
+				}
+			}
+		}
+	})
+
+	for _, callID := range callOrder {
+		call := calls[callID]
+		result := results[callID]
+		trace.Events = append(trace.Events, adapter.BuildEvent(trace, call, result))
+	}
+	for i := range trace.Events {
+		trace.Events[i].Seq = i
+	}
+	if trace.Session.Title == "" {
+		trace.Session.Title = filepath.Base(path)
+	}
+	trace.Session.EventCount = len(trace.Events)
+	trace.Stats = model.ComputeStats(trace, 0, model.ObservabilityEstimated)
+	if !sawSession {
+		return nil, fmt.Errorf("not a Pi session: %s", path)
+	}
+	return trace, err
+}
+
+type rawLine struct {
+	Type      string      `json:"type"`
+	ID        string      `json:"id"`
+	ParentID  string      `json:"parentId"`
+	Timestamp string      `json:"timestamp"`
+	Cwd       string      `json:"cwd"`
+	ModelID   string      `json:"modelId"`
+	Provider  string      `json:"provider"`
+	Message   *rawMessage `json:"message"`
+}
+
+type rawMessage struct {
+	Role       string           `json:"role"`
+	Content    []rawContentItem `json:"content"`
+	ToolCallID string           `json:"toolCallId"`
+	ToolName   string           `json:"toolName"`
+	IsError    bool             `json:"isError"`
+	Timestamp  int64            `json:"timestamp"`
+}
+
+type rawContentItem struct {
+	Type      string         `json:"type"`
+	ID        string         `json:"id"`
+	Name      string         `json:"name"`
+	Text      string         `json:"text"`
+	Thinking  string         `json:"thinking"`
+	Arguments map[string]any `json:"arguments"`
+}
+
+func applyLineTime(trace *model.Trace, ts string) {
+	if ts == "" {
+		return
+	}
+	if trace.Session.StartedAt == "" {
+		trace.Session.StartedAt = ts
+	}
+	trace.Session.EndedAt = ts
+}
+
+func contentItemsToString(items []rawContentItem) string {
+	parts := make([]string, 0, len(items))
+	for _, item := range items {
+		if item.Type == "text" && item.Text != "" {
+			parts = append(parts, item.Text)
+		}
+	}
+	return strings.Join(parts, "\n")
+}
+
+// normalizeInput maps Pi tool arguments to the canonical keys expected by
+// adapter.targetsFor (e.g. Pi uses "path" while adapter expects "file_path" for Read).
+func normalizeInput(tool string, args map[string]any) map[string]any {
+	if args == nil {
+		return map[string]any{}
+	}
+	out := make(map[string]any, len(args))
+	for k, v := range args {
+		out[k] = v
+	}
+	switch tool {
+	case "read":
+		if path, ok := out["path"]; ok {
+			if _, exists := out["file_path"]; !exists {
+				out["file_path"] = path
+			}
+		}
+	case "find":
+		if pattern, ok := out["pattern"]; ok {
+			if _, exists := out["path"]; !exists {
+				out["path"] = pattern
+			}
+		}
+	}
+	return out
+}
+
+// normalizeToolName maps Pi tool names to the canonical names expected by
+// adapter.actionFor / adapter.targetsFor.
+func normalizeToolName(name string) string {
+	switch name {
+	case "read":
+		return "Read"
+	case "write":
+		return "Write"
+	case "edit":
+		return "Edit"
+	case "bash":
+		return "Bash"
+	case "grep":
+		return "Grep"
+	case "find", "ls":
+		return "Glob"
+	case "fetch_content":
+		return "Read"
+	case "ast_grep_outline", "ast_grep_search", "ast_grep_scan":
+		return "Grep"
+	case "ast_grep_rewrite":
+		return "Edit"
+	default:
+		return name
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cosmtrek/mindwalk/internal/adapter"
 	"github.com/cosmtrek/mindwalk/internal/adapter/claudecode"
 	"github.com/cosmtrek/mindwalk/internal/adapter/codex"
+	"github.com/cosmtrek/mindwalk/internal/adapter/pi"
 	"github.com/cosmtrek/mindwalk/internal/citymap"
 	"github.com/cosmtrek/mindwalk/internal/model"
 )
@@ -33,6 +34,7 @@ type Config struct {
 	Port        int
 	ClaudeDir   string
 	CodexDir    string
+	PiDir       string
 	OpenSession string
 	Dev         bool
 	RepoRoot    string
@@ -95,7 +97,7 @@ const (
 func New(cfg Config) *Server {
 	return &Server{
 		cfg:       cfg,
-		adapters:  []adapter.Source{claudecode.Adapter{Dir: cfg.ClaudeDir}, codex.Adapter{Dir: cfg.CodexDir}},
+		adapters:  []adapter.Source{pi.Adapter{Dir: cfg.PiDir}, claudecode.Adapter{Dir: cfg.ClaudeDir}, codex.Adapter{Dir: cfg.CodexDir}},
 		traces:    map[string]*model.Trace{},
 		maps:      map[string]*model.CityMap{},
 		cacheAt:   map[string]time.Time{},

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -26,7 +26,7 @@ func TestTraceStillLoadsWhenSessionCwdIsMissing(t *testing.T) {
 		`{"type":"user","timestamp":"2026-07-09T00:00:02Z","sessionId":"missingcwd","cwd":`+quoteJSON(missingRoot)+`,"message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"r1","content":"ok","is_error":false}]}}`,
 	)
 
-	s := New(Config{ClaudeDir: claudeDir, CodexDir: filepath.Join(t.TempDir(), "codex")})
+	s := New(Config{ClaudeDir: claudeDir, CodexDir: filepath.Join(t.TempDir(), "codex"), PiDir: t.TempDir()})
 	traceResp := httptest.NewRecorder()
 	s.handleSessionResource(traceResp, httptest.NewRequest(http.MethodGet, "/api/sessions/missingcwd/trace", nil))
 	if traceResp.Code != http.StatusOK {
@@ -77,7 +77,7 @@ func TestOpenSessionUsesUniqueKeyAndFindSessionAcceptsBasename(t *testing.T) {
 		`{"type":"user","timestamp":"2026-07-09T00:00:00Z","sessionId":"internal-id","cwd":"/tmp","message":{"role":"user","content":"hello"}}`,
 	)
 
-	s := New(Config{ClaudeDir: claudeDir, CodexDir: filepath.Join(t.TempDir(), "codex"), OpenSession: session})
+	s := New(Config{ClaudeDir: claudeDir, CodexDir: filepath.Join(t.TempDir(), "codex"), PiDir: t.TempDir(), OpenSession: session})
 	wantKey := adapter.SessionKey("claude-code", session)
 	if got := s.openSessionKey(); got != wantKey {
 		t.Fatalf("openSessionKey = %q, want %q", got, wantKey)
@@ -108,7 +108,7 @@ func TestDuplicateSessionIDsUseDistinctKeysAndCaches(t *testing.T) {
 		})
 	}
 
-	s := New(Config{ClaudeDir: claudeDir, CodexDir: codexDir})
+	s := New(Config{ClaudeDir: claudeDir, CodexDir: codexDir, PiDir: t.TempDir()})
 	sessions, err := s.listSessions()
 	if err != nil {
 		t.Fatal(err)
@@ -153,7 +153,7 @@ func TestTraceCacheReloadsWhenActiveSessionGrows(t *testing.T) {
 		`{"type":"user","timestamp":"2026-07-09T00:00:02Z","sessionId":"growing","cwd":`+quoteJSON(repoRoot)+`,"message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"r1","content":"ok","is_error":false}]}}`,
 	)
 
-	s := New(Config{ClaudeDir: claudeDir, CodexDir: filepath.Join(t.TempDir(), "codex")})
+	s := New(Config{ClaudeDir: claudeDir, CodexDir: filepath.Join(t.TempDir(), "codex"), PiDir: t.TempDir()})
 	firstTrace, firstCity, err := s.traceAndMap("growing")
 	if err != nil {
 		t.Fatal(err)
@@ -187,7 +187,7 @@ func TestSessionsFreshBypassesListTTL(t *testing.T) {
 	writeServerSession(t, filepath.Join(claudeDir, "first.jsonl"),
 		`{"type":"user","timestamp":"2026-07-09T00:00:00Z","sessionId":"first","cwd":"/tmp","message":{"role":"user","content":"hello"}}`,
 	)
-	s := New(Config{ClaudeDir: claudeDir, CodexDir: filepath.Join(t.TempDir(), "codex")})
+	s := New(Config{ClaudeDir: claudeDir, CodexDir: filepath.Join(t.TempDir(), "codex"), PiDir: t.TempDir()})
 
 	initial := requestSessions(t, s, "/api/sessions")
 	if len(initial) != 1 {
@@ -212,7 +212,7 @@ func TestConcurrentFreshGenerationReusesCompletedScan(t *testing.T) {
 	writeServerSession(t, filepath.Join(claudeDir, "session.jsonl"),
 		`{"type":"user","timestamp":"2026-07-09T00:00:00Z","sessionId":"session","cwd":"/tmp","message":{"role":"user","content":"hello"}}`,
 	)
-	s := New(Config{ClaudeDir: claudeDir, CodexDir: filepath.Join(t.TempDir(), "codex")})
+	s := New(Config{ClaudeDir: claudeDir, CodexDir: filepath.Join(t.TempDir(), "codex"), PiDir: t.TempDir()})
 
 	// Two fresh callers that enter before either scan completes observe the
 	// same generation. The second must reuse the first completed scan.
@@ -325,7 +325,7 @@ func TestServerLoadsCodexSessions(t *testing.T) {
 		},
 	)
 
-	s := New(Config{ClaudeDir: claudeDir, CodexDir: codexDir})
+	s := New(Config{ClaudeDir: claudeDir, CodexDir: codexDir, PiDir: t.TempDir()})
 	sessionsResp := httptest.NewRecorder()
 	s.handleSessions(sessionsResp, httptest.NewRequest(http.MethodGet, "/api/sessions", nil))
 	if sessionsResp.Code != http.StatusOK {
@@ -367,7 +367,7 @@ func TestServerSkipsClaudeSubagentSessions(t *testing.T) {
 		`{"type":"user","timestamp":"2026-07-09T00:00:01Z","sessionId":"subagent","cwd":"/tmp","message":{"role":"user","content":"internal"}}`,
 	)
 
-	s := New(Config{ClaudeDir: claudeDir, CodexDir: filepath.Join(t.TempDir(), "codex")})
+	s := New(Config{ClaudeDir: claudeDir, CodexDir: filepath.Join(t.TempDir(), "codex"), PiDir: t.TempDir()})
 	sessions, err := s.scanSessions()
 	if err != nil {
 		t.Fatal(err)
@@ -416,7 +416,7 @@ func TestServerSkipsCodexSubagentSessions(t *testing.T) {
 		},
 	)
 
-	s := New(Config{ClaudeDir: claudeDir, CodexDir: codexDir})
+	s := New(Config{ClaudeDir: claudeDir, CodexDir: codexDir, PiDir: t.TempDir()})
 	sessions, err := s.scanSessions()
 	if err != nil {
 		t.Fatal(err)
@@ -427,7 +427,7 @@ func TestServerSkipsCodexSubagentSessions(t *testing.T) {
 
 	// Default discovery hides auxiliary rollouts, while an explicitly opened
 	// path remains available for targeted inspection.
-	explicit := New(Config{ClaudeDir: claudeDir, CodexDir: codexDir, OpenSession: subagentSession})
+	explicit := New(Config{ClaudeDir: claudeDir, CodexDir: codexDir, PiDir: t.TempDir(), OpenSession: subagentSession})
 	explicitSessions, err := explicit.listSessions()
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
## Summary

Adds adapter for [Pi](https://github.com/pi) coding agent session logs (`~/.pi/agent/sessions/`).

## What it does

- Reads Pi session JSONL and produces the same `Trace` / `Event` / `Mark` output as the existing Claude Code and Codex adapters
- Normalizes Pi's `toolCall`/`toolResult` format and lowercase tool names to the canonical adapter contract
- Wires into `mindwalk serve` (`--pi-dir`), `mindwalk open`, and `mindwalk trace`

## Design decisions

| Concern | Decision |
|---|---|
| Recognition | Require `{"type":"session",...}` line to avoid false-matching Codex/Claude logs that also use `"type":"message"` |
| Tool mapping | `read→Read`, `write→Write`, `edit→Edit`, `bash→Bash`, `grep→Grep`, `find/ls→Glob`, `fetch_content→Read`, `ast_grep_*→Grep/Edit` |
| Input normalization | `read` uses `path` not `file_path`; `find` uses `pattern` not `path` — normalized before passing to shared `targetsFor` |
| Adapter order | Pi placed first in adapter lists so Pi sessions aren't accidentally claimed by the Codex adapter |

## Tested

- `go build ./...` ✅
- `go test ./...` (all) ✅
- `mindwalk trace <pi-session>` → correct harness, events, marks, targets ✅
- `mindwalk serve` → 363 Pi sessions loaded alongside existing Codex sessions ✅

## Files

- **new**: `internal/adapter/pi/adapter.go` — 230-line Pi adapter
- **modified**: `cmd/mindwalk/main.go` — `--pi-dir` flag, adapter in trace/parse
- **modified**: `internal/server/server.go` — PiDir config, adapter registration
- **modified**: `internal/server/server_test.go` — PiDir: t.TempDir() in test Configs