### PR TITLE
fix: detect nested apply_patch calls in Codex exec events

### DIFF
--- a/internal/adapter/adapter.go
+++ b/internal/adapter/adapter.go
@@ -143,6 +143,9 @@ func actionFor(tool string, input map[string]any, result string) string {
 		}
 		return "exec"
 	case "exec":
+		if len(execPatchPaths(input)) > 0 {
+			return "edit"
+		}
 		commands := execCommands(input)
 		if len(commands) == 0 || !execHasOnlyStaticCommands(input, len(commands)) {
 			return "exec"
@@ -277,6 +280,9 @@ func targetsFor(cwd, tool string, input map[string]any, result string) ([]model.
 		for _, hit := range parsePathHits(result) {
 			add(hit.path, "hit", true, hit.lines, "")
 		}
+		for _, path := range execPatchPaths(input) {
+			add(path, "edit", false, nil, "")
+		}
 	case "apply_patch":
 		patch := firstString(input, "patch", "input", "_raw")
 		for _, path := range parsePatchPaths(patch) {
@@ -313,6 +319,7 @@ type execCommand struct {
 // literals assigned to cmd or workdir. It intentionally does not attempt to
 // parse arbitrary JavaScript expressions.
 var execStringFieldRe = regexp.MustCompile(`(?:^|[[:space:],{])(?:"(cmd|workdir)"|(cmd|workdir))\s*:\s*("(?:\\.|[^"\\])*")`)
+var execPatchAssignmentRe = regexp.MustCompile(`(?m)^[\t ]*(?:const|let|var)[\t ]+patch[\t ]*=[\t ]*("(?:\\.|[^"\\])*")[\t ]*;`)
 
 func execSource(input map[string]any) string {
 	for _, key := range []string{"_raw", "code", "script"} {
@@ -359,6 +366,27 @@ func execCommands(input map[string]any) []execCommand {
 	return commands
 }
 
+func execPatchPaths(input map[string]any) []string {
+	source := execSource(input)
+	if source == "" {
+		return nil
+	}
+	match := execPatchAssignmentRe.FindStringSubmatch(source)
+	if len(match) != 2 {
+		return nil
+	}
+	var patch string
+	if json.Unmarshal([]byte(match[1]), &patch) != nil {
+		return nil
+	}
+	for _, argument := range execToolArguments(source, "apply_patch") {
+		if strings.TrimSpace(argument) == "patch" {
+			return parsePatchPaths(patch)
+		}
+	}
+	return nil
+}
+
 func parseStaticExecCommand(argument string) (execCommand, bool) {
 	var command execCommand
 	ambiguousWorkdir := false
@@ -395,7 +423,11 @@ func parseStaticExecCommand(argument string) (execCommand, bool) {
 }
 
 func execCommandArguments(source string) []string {
-	const call = "tools.exec_command"
+	return execToolArguments(source, "exec_command")
+}
+
+func execToolArguments(source, tool string) []string {
+	call := "tools." + tool
 	var arguments []string
 	for i := 0; i < len(source); {
 		if next, ok := skipJSIgnored(source, i); ok {

--- a/internal/adapter/adapter_test.go
+++ b/internal/adapter/adapter_test.go
@@ -37,6 +37,21 @@ func TestBuildEventKeepsExecAggregatedAndFindsSingleCommandTarget(t *testing.T) 
 	}
 }
 
+func TestBuildEventExtractsApplyPatchFromExec(t *testing.T) {
+	root := t.TempDir()
+	writeAdapterTestFile(t, root, "src/main.go")
+	patch := "*** Begin Patch\n*** Update File: src/main.go\n@@\n-old\n+new\n*** End Patch"
+	source := `const patch = ` + jsonString(t, patch) + `; text(await tools.apply_patch(patch));`
+
+	event := buildExecEvent(root, map[string]any{"_raw": source})
+	if event.Tool != "exec" || event.Action != "edit" {
+		t.Fatalf("event = %#v", event)
+	}
+	if len(event.Targets) != 1 || event.Targets[0].Path != "src/main.go" || event.Targets[0].Touch != "edit" || event.Targets[0].Weak {
+		t.Fatalf("targets = %#v", event.Targets)
+	}
+}
+
 func TestBuildEventExtractsPromiseAllCommandTargets(t *testing.T) {
 	root := t.TempDir()
 	writeAdapterTestFile(t, root, "first/main.go")


### PR DESCRIPTION
## Summary

Recent Codex sessions can record tool orchestration as a top-level `exec` call whose JavaScript invokes nested tools. Mindwalk already extracts nested `tools.exec_command(...)` calls, but it ignored the generated static patch wrapper:

```js
const patch = "*** Begin Patch\n...";
text(await tools.apply_patch(patch));
```

As a result, real file mutations were normalized as ordinary `exec` events with no edit targets. The UI could report `edited 0`, omit orange edit segments, and produce incorrect churn and post-verify statistics even though the session changed files.

## Fix

- recognize the static `patch` assignment used by the current Codex wrapper
- verify that the value is passed to a real `tools.apply_patch(patch)` call, skipping strings and comments through the existing scanner
- parse patch file paths as strong edit targets
- classify the aggregate event as `edit`
- keep the implementation deliberately static; it does not evaluate arbitrary JavaScript

## Tests

- added a regression test for the generated wrapper shape
- `make test`
- `go test -race ./internal/adapter ./internal/adapter/codex -count=1`