### PR TITLE
fix: mark Codex spawn_agent calls as subagents

### DIFF
--- a/internal/adapter/codex/adapter.go
+++ b/internal/adapter/codex/adapter.go
@@ -218,6 +218,9 @@ func (a Adapter) Parse(path string) (*model.Trace, error) {
 				if _, exists := calls[call.ID]; exists {
 					return
 				}
+				if call.Name == "spawn_agent" {
+					trace.Marks = append(trace.Marks, model.Mark{Seq: len(callOrder), Type: "subagent", Note: call.Name})
+				}
 				calls[call.ID] = call
 				callOrder = append(callOrder, call.ID)
 				directPatches[call.ID] = source == "custom_tool_call" && call.Name == "apply_patch"

--- a/internal/adapter/codex/adapter_test.go
+++ b/internal/adapter/codex/adapter_test.go
@@ -145,6 +145,36 @@ func TestParseCodexContextCompactedBecomesCompactionMark(t *testing.T) {
 	}
 }
 
+func TestParseCodexSpawnAgentBecomesSubagentMark(t *testing.T) {
+	dir := t.TempDir()
+	session := filepath.Join(dir, "rollout-2026-07-14T00-00-00-codex-subagent.jsonl")
+	writeJSONL(t, session,
+		map[string]any{
+			"timestamp": "2026-07-14T00:00:00Z",
+			"type":      "session_meta",
+			"payload":   map[string]any{"id": "codex-subagent", "timestamp": "2026-07-14T00:00:00Z"},
+		},
+		call("2026-07-14T00:00:01Z", "fc-1", "call-1", "exec_command", map[string]any{"cmd": "true"}),
+		output("2026-07-14T00:00:02Z", "call-1", "Process exited with code 0"),
+		call("2026-07-14T00:00:03Z", "fc-2", "call-2", "spawn_agent", map[string]any{
+			"task_name": "qa",
+			"message":   "Review the change",
+		}),
+		output("2026-07-14T00:00:04Z", "call-2", `{"agent_id":"agent-1"}`),
+	)
+
+	trace, err := Adapter{Dir: dir}.Parse(session)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(trace.Marks) != 1 || trace.Marks[0].Type != "subagent" || trace.Marks[0].Seq != 1 || trace.Marks[0].Note != "spawn_agent" {
+		t.Fatalf("marks = %#v", trace.Marks)
+	}
+	if trace.Stats.Subagents != 1 {
+		t.Fatalf("subagents = %d", trace.Stats.Subagents)
+	}
+}
+
 func TestParseCodexCustomCallsCanonicalizesOrderAndPatchResults(t *testing.T) {
 	root := t.TempDir()
 	readme := filepath.Join(root, "README.md")


### PR DESCRIPTION
## Problem

Codex records `spawn_agent` as a regular `function_call`. The adapter already emitted the corresponding event, but it did not add the existing `subagent` timeline mark. As a result, real Codex sessions showed `0 subagents` even when agents were spawned.

## Fix

- add a `subagent` mark for each accepted, unique `spawn_agent` call
- keep the mark sequence aligned with the spawn event
- use `spawn_agent` as the mark note, matching the Claude Code adapter pattern
- add a regression test covering the timeline mark and derived statistic

## Verification

- `go test ./internal/adapter/codex -run TestParseCodexSpawnAgentBecomesSubagentMark -count=1`
- `go test ./internal/adapter/codex -count=1`
- `go test ./... -count=1`
- real Codex trace: 1 spawn event -> 1 subagent mark -> `stats.subagents = 1`
- independent QA gate: PASS