### PR TITLE
fix: drop removed Codex judge feature flag

### DIFF
--- a/internal/judge/cli.go
+++ b/internal/judge/cli.go
@@ -131,30 +131,7 @@ func (r CLIRunner) Run(ctx context.Context, prompt, input string) (RunResult, er
 		// self-reports): with this set the judge cannot read local files,
 		// fetch URLs, apply patches, or spawn collaboration agents — each
 		// attempt fails at the tool router or sandbox.
-		args := []string{"exec",
-			"--ephemeral",          // no session file for mindwalk to re-scan
-			"--ignore-user-config", // no user MCP servers or profiles; auth stays
-			"--ignore-rules",       // no user/project execpolicy rules
-			"--disable", "shell_tool",
-			"--disable", "browser_use",
-			"--disable", "browser_use_external",
-			"--disable", "browser_use_full_cdp_access",
-			"--disable", "computer_use",
-			"--disable", "in_app_browser",
-			"--disable", "apps",
-			"--disable", "plugins",
-			"--disable", "hooks",
-			"--disable", "multi_agent",
-			"--disable", "multi_agent_v2",
-			"--disable", "memories",
-			"--disable", "image_generation",
-			"-c", "include_apply_patch_tool=false",
-			"-c", "tools.view_image=false",
-			"-c", `web_search="disabled"`,
-			"--sandbox", "read-only", // defense in depth behind the tool strip
-			"--skip-git-repo-check", // the judge workdir is not a repository
-			"-C", workdir,
-		}
+		args := codexExecArgs(workdir)
 		if r.Model != "" {
 			args = append(args, "-c", "model="+r.Model)
 		}
@@ -187,6 +164,32 @@ func (r CLIRunner) Run(ctx context.Context, prompt, input string) (RunResult, er
 		model = codexModel(stdout.String())
 	}
 	return RunResult{Text: stdout.String(), Model: model}, nil
+}
+
+func codexExecArgs(workdir string) []string {
+	return []string{"exec",
+		"--ephemeral",          // no session file for mindwalk to re-scan
+		"--ignore-user-config", // no user MCP servers or profiles; auth stays
+		"--ignore-rules",       // no user/project execpolicy rules
+		"--disable", "shell_tool",
+		"--disable", "browser_use",
+		"--disable", "browser_use_external",
+		"--disable", "computer_use",
+		"--disable", "in_app_browser",
+		"--disable", "apps",
+		"--disable", "plugins",
+		"--disable", "hooks",
+		"--disable", "multi_agent",
+		"--disable", "multi_agent_v2",
+		"--disable", "memories",
+		"--disable", "image_generation",
+		"-c", "include_apply_patch_tool=false",
+		"-c", "tools.view_image=false",
+		"-c", `web_search="disabled"`,
+		"--sandbox", "read-only", // defense in depth behind the tool strip
+		"--skip-git-repo-check", // the judge workdir is not a repository
+		"-C", workdir,
+	}
 }
 
 // claudeEnvelope mirrors the parts of `claude -p --output-format json` output

--- a/internal/judge/cli_test.go
+++ b/internal/judge/cli_test.go
@@ -1,6 +1,9 @@
 package judge
 
-import "testing"
+import (
+	"slices"
+	"testing"
+)
 
 func TestParseClaudeEnvelopePicksMainModel(t *testing.T) {
 	raw := `{"type":"result","result":"{\"ok\":true}","modelUsage":{
@@ -32,5 +35,12 @@ func TestCodexModelReadsPreamble(t *testing.T) {
 	}
 	if got := codexModel("no preamble at all"); got != "" {
 		t.Fatalf("expected empty model, got %q", got)
+	}
+}
+
+func TestCodexExecArgsExcludeRemovedFeatures(t *testing.T) {
+	args := codexExecArgs("/tmp/judge")
+	if slices.Contains(args, "browser_use_full_cdp_access") {
+		t.Fatal("codex args include removed browser_use_full_cdp_access feature")
 	}
 }


### PR DESCRIPTION
## What

Remove the obsolete `browser_use_full_cdp_access` feature disable from the Codex judge command.

Codex CLI 0.142.0 rejects that feature before the judge starts:

```text
Error: Unknown feature flag: browser_use_full_cdp_access
```

As a result, every `mindwalk analyze --judge codex` run fails before reaching the model.

The parent browser capabilities remain disabled through `browser_use` and `browser_use_external`. The existing shell, computer-use, apps, plugins, hooks, multi-agent, memories, image generation, apply-patch, view-image, web-search, read-only sandbox, and isolated-workdir protections are unchanged.

The Codex argument construction is extracted into a small helper so the removed feature has a direct regression test.

## Verification

- `go test -race ./internal/judge`
- `make test`
- `git diff --check`
- Codex CLI 0.142.0 rejects the removed flag and accepts every remaining `--disable` feature

No live judge inference was needed for this compatibility fix; the current CLI successfully parses the corrected argument set.