### PR TITLE
fix: preserve UTF-8 in command summaries

### DIFF
--- a/internal/adapter/adapter.go
+++ b/internal/adapter/adapter.go
@@ -960,9 +960,10 @@ func SummarizeTool(tool string, input map[string]any, targets []model.Target, ou
 		verb = desc
 	}
 	if command := firstString(input, "command", "cmd"); command != "" {
+		commandRunes := []rune(command)
 		verb = command
-		if len(verb) > 96 {
-			verb = verb[:93] + "..."
+		if len(commandRunes) > 96 {
+			verb = string(commandRunes[:93]) + "..."
 		}
 	}
 	status := ""

--- a/internal/adapter/adapter_test.go
+++ b/internal/adapter/adapter_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/cosmtrek/mindwalk/internal/model"
 )
@@ -36,6 +37,19 @@ func TestUserMessageNoteStaysWithinRuneBudget(t *testing.T) {
 	exact := strings.Repeat("a", userMessageNoteLimit)
 	if UserMessageNote(exact) != exact {
 		t.Fatal("text at the limit must pass through untouched")
+	}
+}
+
+func TestSummarizeToolTruncatesCommandAtRuneBoundary(t *testing.T) {
+	command := strings.Repeat("a", 92) + "界tail"
+	summary := SummarizeTool("exec", map[string]any{"cmd": command}, nil, nil, false)
+
+	if !utf8.ValidString(summary) {
+		t.Fatalf("summary contains invalid UTF-8: %q", summary)
+	}
+	want := strings.Repeat("a", 92) + "界... -> 0 targets, 0 outside"
+	if summary != want {
+		t.Fatalf("summary = %q, want %q", summary, want)
 	}
 }
 


### PR DESCRIPTION
Summary:
- truncate command summaries by Unicode rune instead of raw bytes
- prevent multibyte commands from producing invalid UTF-8 judge input
- add a regression test for a truncation boundary inside a Chinese character

Tests:
- make test