### PR TITLE
fix: preserve UTF-8 in judge errors

### DIFF
--- a/internal/judge/cli.go
+++ b/internal/judge/cli.go
@@ -149,9 +149,7 @@ func (r CLIRunner) Run(ctx context.Context, prompt, input string) (RunResult, er
 		if detail == "" {
 			detail = strings.TrimSpace(stdout.String())
 		}
-		if len(detail) > 500 {
-			detail = detail[:500]
-		}
+		detail = truncateFailureDetail(detail)
 		return RunResult{}, fmt.Errorf("%s failed: %w: %s", r.CLI, err, detail)
 	}
 	if r.CLI == "claude" {
@@ -164,6 +162,14 @@ func (r CLIRunner) Run(ctx context.Context, prompt, input string) (RunResult, er
 		model = codexModel(stdout.String())
 	}
 	return RunResult{Text: stdout.String(), Model: model}, nil
+}
+
+func truncateFailureDetail(detail string) string {
+	runes := []rune(detail)
+	if len(runes) > 500 {
+		return string(runes[:500])
+	}
+	return detail
 }
 
 func codexExecArgs(workdir string) []string {

--- a/internal/judge/cli_test.go
+++ b/internal/judge/cli_test.go
@@ -2,7 +2,9 @@ package judge
 
 import (
 	"slices"
+	"strings"
 	"testing"
+	"unicode/utf8"
 )
 
 func TestParseClaudeEnvelopePicksMainModel(t *testing.T) {
@@ -42,5 +44,18 @@ func TestCodexExecArgsExcludeRemovedFeatures(t *testing.T) {
 	args := codexExecArgs("/tmp/judge")
 	if slices.Contains(args, "browser_use_full_cdp_access") {
 		t.Fatal("codex args include removed browser_use_full_cdp_access feature")
+	}
+}
+
+func TestTruncateFailureDetailPreservesUTF8(t *testing.T) {
+	detail := strings.Repeat("a", 499) + "界tail"
+	got := truncateFailureDetail(detail)
+
+	if !utf8.ValidString(got) {
+		t.Fatalf("truncated detail is not valid UTF-8: %q", got)
+	}
+	want := strings.Repeat("a", 499) + "界"
+	if got != want {
+		t.Fatalf("truncated detail = %q, want %q", got, want)
 	}
 }


### PR DESCRIPTION
## Summary

Judge CLI failures cap stderr/stdout detail at 500 characters before returning the error. That path currently slices the Go string at 500 raw bytes, which can split a multibyte Unicode character and produce invalid UTF-8.

This change:

- truncates failure detail by Unicode rune instead of byte
- preserves the existing 500-character cap and error format
- adds a regression test whose boundary lands on a Chinese character

This is the same class of UTF-8 boundary issue fixed for command summaries in #11, applied to the Judge failure path.

## Tests

- `go test -race ./internal/judge -count=1`
- `make test`
- `git diff --check`

Independent QA gate: **PASS**.
