### PR TITLE
fix(trace): preserve tool outcome certainty

### DIFF
--- a/internal/adapter/adapter.go
+++ b/internal/adapter/adapter.go
@@ -46,8 +46,9 @@ type ToolCall struct {
 }
 
 type ToolResult struct {
-	Content string
-	IsError bool
+	Content      string
+	IsError      bool
+	OutcomeKnown bool
 }
 
 // SessionKey identifies one session file independently of the harness-level
@@ -199,15 +200,16 @@ func BuildEvent(trace *model.Trace, call ToolCall, result ToolResult) model.Even
 		targets = []model.Target{}
 	}
 	return model.Event{
-		Seq:         len(trace.Events),
-		Timestamp:   call.Timestamp,
-		Tool:        call.Name,
-		Action:      action,
-		Targets:     targets,
-		Outside:     outside,
-		ResultBytes: len(result.Content),
-		IsError:     result.IsError,
-		Summary:     SummarizeTool(call.Name, call.Input, targets, outside, result.IsError),
+		Seq:          len(trace.Events),
+		Timestamp:    call.Timestamp,
+		Tool:         call.Name,
+		Action:       action,
+		Targets:      targets,
+		Outside:      outside,
+		ResultBytes:  len(result.Content),
+		IsError:      result.IsError,
+		OutcomeKnown: result.OutcomeKnown,
+		Summary:      SummarizeTool(call.Name, call.Input, targets, outside, result.IsError),
 	}
 }
 

--- a/internal/adapter/adapter_test.go
+++ b/internal/adapter/adapter_test.go
@@ -323,6 +323,21 @@ func TestBuildEventClassifiesBashSearchCommands(t *testing.T) {
 	}
 }
 
+func TestBuildEventPreservesOutcomeCertainty(t *testing.T) {
+	trace := &model.Trace{Session: model.TraceSession{Cwd: t.TempDir()}}
+	call := ToolCall{Name: "Bash", Input: map[string]any{"command": "go test ./..."}}
+
+	known := BuildEvent(trace, call, ToolResult{OutcomeKnown: true})
+	if !known.OutcomeKnown || known.IsError {
+		t.Fatalf("known event = %#v", known)
+	}
+
+	unknown := BuildEvent(trace, call, ToolResult{})
+	if unknown.OutcomeKnown || unknown.IsError {
+		t.Fatalf("unknown event = %#v", unknown)
+	}
+}
+
 func TestBuildEventExecActionAllSearchCommands(t *testing.T) {
 	source := `Promise.all([tools.exec_command({cmd:"rg TODO main.go"}), tools.exec_command({cmd:"ls src"})])`
 	event := buildExecEvent(t.TempDir(), map[string]any{"_raw": source})

--- a/internal/adapter/claudecode/adapter.go
+++ b/internal/adapter/claudecode/adapter.go
@@ -243,14 +243,14 @@ func (a Adapter) Parse(path string) (*model.Trace, error) {
 					continue
 				}
 				delete(pending, item.ToolUseID)
-				event := buildEvent(trace, call, item)
+				event := buildEvent(trace, call, item, true)
 				trace.Events = append(trace.Events, event)
 			}
 		}
 	})
 	for _, id := range pendingOrder {
 		if call, ok := pending[id]; ok {
-			trace.Events = append(trace.Events, buildEvent(trace, call, contentItem{}))
+			trace.Events = append(trace.Events, buildEvent(trace, call, contentItem{}, false))
 		}
 	}
 	sort.Slice(trace.Events, func(i, j int) bool {
@@ -307,6 +307,22 @@ func (c *contentList) UnmarshalJSON(data []byte) error {
 	var items []contentItem
 	if err := json.Unmarshal(data, &items); err != nil {
 		return err
+	}
+	var rawItems []map[string]json.RawMessage
+	if err := json.Unmarshal(data, &rawItems); err != nil {
+		return err
+	}
+	for i := range items {
+		items[i].IsError = nil
+		raw, ok := rawItems[i]["is_error"]
+		if !ok || strings.TrimSpace(string(raw)) == "null" {
+			continue
+		}
+		var value bool
+		if err := json.Unmarshal(raw, &value); err != nil {
+			return err
+		}
+		items[i].IsError = &value
 	}
 	c.Items = items
 	return nil
@@ -389,11 +405,11 @@ func isClaudeLine(line rawLine) bool {
 	}
 }
 
-func buildEvent(trace *model.Trace, call adapter.ToolCall, result contentItem) model.Event {
+func buildEvent(trace *model.Trace, call adapter.ToolCall, result contentItem, resultObserved bool) model.Event {
 	isError := result.IsError != nil && *result.IsError
 	return adapter.BuildEvent(trace, call, adapter.ToolResult{
 		Content:      adapter.ContentToString(result.Content),
 		IsError:      isError,
-		OutcomeKnown: result.IsError != nil,
+		OutcomeKnown: resultObserved,
 	})
 }

--- a/internal/adapter/claudecode/adapter.go
+++ b/internal/adapter/claudecode/adapter.go
@@ -319,7 +319,7 @@ type contentItem struct {
 	Input     map[string]any `json:"input"`
 	ToolUseID string         `json:"tool_use_id"`
 	Content   any            `json:"content"`
-	IsError   bool           `json:"is_error"`
+	IsError   *bool          `json:"is_error"`
 	Text      string         `json:"text"`
 }
 
@@ -390,8 +390,10 @@ func isClaudeLine(line rawLine) bool {
 }
 
 func buildEvent(trace *model.Trace, call adapter.ToolCall, result contentItem) model.Event {
+	isError := result.IsError != nil && *result.IsError
 	return adapter.BuildEvent(trace, call, adapter.ToolResult{
-		Content: adapter.ContentToString(result.Content),
-		IsError: result.IsError,
+		Content:      adapter.ContentToString(result.Content),
+		IsError:      isError,
+		OutcomeKnown: result.IsError != nil,
 	})
 }

--- a/internal/adapter/claudecode/adapter_test.go
+++ b/internal/adapter/claudecode/adapter_test.go
@@ -95,15 +95,15 @@ func TestParsePreservesToolOutcomeCertainty(t *testing.T) {
 	session := filepath.Join(t.TempDir(), "outcome-certainty.jsonl")
 	writeSession(t, session,
 		`{"type":"user","timestamp":"2026-07-09T00:00:00Z","cwd":"/tmp","sessionId":"outcome-certainty","message":{"role":"user","content":"x"}}`,
-		`{"type":"assistant","timestamp":"2026-07-09T00:00:01Z","cwd":"/tmp","sessionId":"outcome-certainty","message":{"role":"assistant","content":[{"type":"tool_use","id":"success","name":"Bash","input":{"command":"go test ./..."}},{"type":"tool_use","id":"failure","name":"Bash","input":{"command":"make test"}},{"type":"tool_use","id":"unknown","name":"Bash","input":{"command":"npm test"}}]}}`,
-		`{"type":"user","timestamp":"2026-07-09T00:00:02Z","cwd":"/tmp","sessionId":"outcome-certainty","message":{"role":"user","content":[{"tool_use_id":"success","type":"tool_result","content":"ok","is_error":false},{"tool_use_id":"failure","type":"tool_result","content":"failed","is_error":true},{"tool_use_id":"unknown","type":"tool_result","content":"incomplete"}]}}`,
+		`{"type":"assistant","timestamp":"2026-07-09T00:00:01Z","cwd":"/tmp","sessionId":"outcome-certainty","message":{"role":"assistant","content":[{"type":"tool_use","id":"explicit-success","name":"Bash","input":{"command":"go test ./..."}},{"type":"tool_use","id":"failure","name":"Bash","input":{"command":"make test"}},{"type":"tool_use","id":"implicit-success","name":"Bash","input":{"command":"npm test"}},{"type":"tool_use","id":"wrong-case","name":"Bash","input":{"command":"go test ./internal/..."}},{"type":"tool_use","id":"pending","name":"Bash","input":{"command":"go vet ./..."}}]}}`,
+		`{"type":"user","timestamp":"2026-07-09T00:00:02Z","cwd":"/tmp","sessionId":"outcome-certainty","message":{"role":"user","content":[{"tool_use_id":"explicit-success","type":"tool_result","content":"ok","is_error":false},{"tool_use_id":"failure","type":"tool_result","content":"failed","is_error":true},{"tool_use_id":"implicit-success","type":"tool_result","content":"ok"},{"tool_use_id":"wrong-case","type":"tool_result","content":"ok","IS_ERROR":true}]}}`,
 	)
 
 	trace, err := (Adapter{}).Parse(session)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(trace.Events) != 3 {
+	if len(trace.Events) != 5 {
 		t.Fatalf("events = %#v", trace.Events)
 	}
 	if got := trace.Events[0]; !got.OutcomeKnown || got.IsError {
@@ -112,8 +112,17 @@ func TestParsePreservesToolOutcomeCertainty(t *testing.T) {
 	if got := trace.Events[1]; !got.OutcomeKnown || !got.IsError {
 		t.Fatalf("failure event = %#v", got)
 	}
-	if got := trace.Events[2]; got.OutcomeKnown || got.IsError {
-		t.Fatalf("unknown event = %#v", got)
+	if got := trace.Events[2]; !got.OutcomeKnown || got.IsError {
+		t.Fatalf("implicit success event = %#v", got)
+	}
+	if got := trace.Events[3]; !got.OutcomeKnown || got.IsError {
+		t.Fatalf("wrong-case error key event = %#v", got)
+	}
+	if got := trace.Events[4]; got.OutcomeKnown || got.IsError {
+		t.Fatalf("pending event = %#v", got)
+	}
+	if trace.Stats.Observability.Errors != "estimated" {
+		t.Fatalf("observability = %#v", trace.Stats.Observability)
 	}
 }
 

--- a/internal/adapter/claudecode/adapter_test.go
+++ b/internal/adapter/claudecode/adapter_test.go
@@ -91,6 +91,32 @@ func TestParsePendingToolUsesRemainDeterministic(t *testing.T) {
 	}
 }
 
+func TestParsePreservesToolOutcomeCertainty(t *testing.T) {
+	session := filepath.Join(t.TempDir(), "outcome-certainty.jsonl")
+	writeSession(t, session,
+		`{"type":"user","timestamp":"2026-07-09T00:00:00Z","cwd":"/tmp","sessionId":"outcome-certainty","message":{"role":"user","content":"x"}}`,
+		`{"type":"assistant","timestamp":"2026-07-09T00:00:01Z","cwd":"/tmp","sessionId":"outcome-certainty","message":{"role":"assistant","content":[{"type":"tool_use","id":"success","name":"Bash","input":{"command":"go test ./..."}},{"type":"tool_use","id":"failure","name":"Bash","input":{"command":"make test"}},{"type":"tool_use","id":"unknown","name":"Bash","input":{"command":"npm test"}}]}}`,
+		`{"type":"user","timestamp":"2026-07-09T00:00:02Z","cwd":"/tmp","sessionId":"outcome-certainty","message":{"role":"user","content":[{"tool_use_id":"success","type":"tool_result","content":"ok","is_error":false},{"tool_use_id":"failure","type":"tool_result","content":"failed","is_error":true},{"tool_use_id":"unknown","type":"tool_result","content":"incomplete"}]}}`,
+	)
+
+	trace, err := (Adapter{}).Parse(session)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(trace.Events) != 3 {
+		t.Fatalf("events = %#v", trace.Events)
+	}
+	if got := trace.Events[0]; !got.OutcomeKnown || got.IsError {
+		t.Fatalf("success event = %#v", got)
+	}
+	if got := trace.Events[1]; !got.OutcomeKnown || !got.IsError {
+		t.Fatalf("failure event = %#v", got)
+	}
+	if got := trace.Events[2]; got.OutcomeKnown || got.IsError {
+		t.Fatalf("unknown event = %#v", got)
+	}
+}
+
 func TestCompactionUsesSubtypeOnly(t *testing.T) {
 	session := filepath.Join(t.TempDir(), "compact.jsonl")
 	writeSession(t, session,

--- a/internal/adapter/claudecode/agents.go
+++ b/internal/adapter/claudecode/agents.go
@@ -236,7 +236,7 @@ func readClaudeAgentLaunches(path string) ([]*claudeAgentLaunch, error) {
 					continue
 				}
 				launch.resultObserved = true
-				launch.resultError = item.IsError
+				launch.resultError = item.IsError != nil && *item.IsError
 			}
 		}
 	})

--- a/internal/adapter/codex/adapter.go
+++ b/internal/adapter/codex/adapter.go
@@ -275,12 +275,14 @@ func (a Adapter) Parse(path string) (*model.Trace, error) {
 				return
 			}
 			if callID, result, ok := decodeOutput(payload); ok {
-				if _, exists := calls[callID]; !exists {
+				call, exists := calls[callID]
+				if !exists {
 					return
 				}
 				if _, exists := results[callID]; exists {
 					return
 				}
+				result.IsError, result.OutcomeKnown = toolOutputStatus(call.Name, result.Content)
 				results[callID] = result
 				return
 			}
@@ -317,6 +319,7 @@ func (a Adapter) Parse(path string) (*model.Trace, error) {
 			if json.Unmarshal(line.Payload, &payload) != nil {
 				return
 			}
+			payload.Success = exactBoolPointer(line.Payload, "success")
 			if payload.Type == "context_compacted" {
 				trace.Marks = append(trace.Marks, model.Mark{Seq: len(callOrder), Type: "compaction"})
 				return
@@ -636,11 +639,8 @@ func decodeOutput(payload responseItemPayload) (string, adapter.ToolResult, bool
 		return "", adapter.ToolResult{}, false
 	}
 	output := adapter.ContentToString(payload.Output)
-	failed, known := commandOutputStatus(output)
 	return payload.CallID, adapter.ToolResult{
-		Content:      output,
-		IsError:      failed,
-		OutcomeKnown: known,
+		Content: output,
 	}, true
 }
 
@@ -724,38 +724,41 @@ var exitCodeRe = regexp.MustCompile(`(?im)^(?:Process exited with code|Exit code
 
 func commandOutputStatus(output string) (failed bool, known bool) {
 	trimmed := strings.TrimSpace(output)
-	var envelope struct {
-		ExitCode *int  `json:"exit_code"`
-		TimedOut *bool `json:"timed_out"`
-		Metadata struct {
-			ExitCode *int `json:"exit_code"`
-		} `json:"metadata"`
-	}
+	var envelope map[string]json.RawMessage
 	if json.Unmarshal([]byte(trimmed), &envelope) == nil {
-		if envelope.ExitCode != nil {
-			return *envelope.ExitCode != 0, true
+		if _, ok := exactString(envelope, "output"); ok {
+			if exitCode, ok := exactInt(envelope, "exit_code"); ok {
+				return exitCode != 0, true
+			}
+			if raw, ok := envelope["metadata"]; ok {
+				var metadata map[string]json.RawMessage
+				if json.Unmarshal(raw, &metadata) == nil {
+					if exitCode, ok := exactInt(metadata, "exit_code"); ok {
+						return exitCode != 0, true
+					}
+				}
+			}
 		}
-		if envelope.Metadata.ExitCode != nil {
-			return *envelope.Metadata.ExitCode != 0, true
+		if _, ok := exactString(envelope, "message"); ok {
+			if timedOut, ok := exactBool(envelope, "timed_out"); ok && timedOut {
+				return true, true
+			}
 		}
-		if envelope.TimedOut != nil && *envelope.TimedOut {
-			return true, true
-		}
-	}
-	if strings.HasPrefix(strings.ToLower(trimmed), "apply_patch verification failed") {
-		return true, true
 	}
 	firstLine := trimmed
 	if newline := strings.IndexByte(firstLine, '\n'); newline >= 0 {
 		firstLine = firstLine[:newline]
 	}
 	status := strings.ToLower(strings.TrimSpace(firstLine))
-	switch {
-	case strings.HasPrefix(status, "script completed"):
+	if strings.HasPrefix(status, "script running with cell id ") {
+		return false, false
+	}
+	switch status {
+	case "script completed":
 		return false, true
-	case strings.HasPrefix(status, "script failed"):
+	case "script failed":
 		return true, true
-	case strings.HasPrefix(status, "script running"):
+	case "script running":
 		return false, false
 	}
 	header := trimmed
@@ -774,6 +777,66 @@ func commandOutputStatus(output string) (failed bool, known bool) {
 		return match[1] != "0", true
 	}
 	return false, false
+}
+
+func toolOutputStatus(tool, output string) (failed bool, known bool) {
+	switch tool {
+	case "exec", "exec_command", "write_stdin", "wait":
+		return commandOutputStatus(output)
+	case "apply_patch":
+		if strings.HasPrefix(strings.ToLower(strings.TrimSpace(output)), "apply_patch verification failed") {
+			return true, true
+		}
+	}
+	return false, false
+}
+
+func exactBoolPointer(data json.RawMessage, key string) *bool {
+	var fields map[string]json.RawMessage
+	if json.Unmarshal(data, &fields) != nil {
+		return nil
+	}
+	value, ok := exactBool(fields, key)
+	if !ok {
+		return nil
+	}
+	return &value
+}
+
+func exactBool(fields map[string]json.RawMessage, key string) (bool, bool) {
+	raw, ok := fields[key]
+	if !ok || strings.TrimSpace(string(raw)) == "null" {
+		return false, false
+	}
+	var value bool
+	if json.Unmarshal(raw, &value) != nil {
+		return false, false
+	}
+	return value, true
+}
+
+func exactInt(fields map[string]json.RawMessage, key string) (int, bool) {
+	raw, ok := fields[key]
+	if !ok || strings.TrimSpace(string(raw)) == "null" {
+		return 0, false
+	}
+	var value int
+	if json.Unmarshal(raw, &value) != nil {
+		return 0, false
+	}
+	return value, true
+}
+
+func exactString(fields map[string]json.RawMessage, key string) (string, bool) {
+	raw, ok := fields[key]
+	if !ok || strings.TrimSpace(string(raw)) == "null" {
+		return "", false
+	}
+	var value string
+	if json.Unmarshal(raw, &value) != nil {
+		return "", false
+	}
+	return value, true
 }
 
 func (a Adapter) titleFor(id string) string {

--- a/internal/adapter/codex/adapter.go
+++ b/internal/adapter/codex/adapter.go
@@ -344,6 +344,7 @@ func (a Adapter) Parse(path string) (*model.Trace, error) {
 			call.Input = applyPatchChanges(call.Input, patchResult.Changes)
 			if patchResult.Success != nil {
 				result.IsError = !*patchResult.Success
+				result.OutcomeKnown = true
 			}
 		}
 		trace.Events = append(trace.Events, adapter.BuildEvent(trace, call, result))
@@ -635,9 +636,11 @@ func decodeOutput(payload responseItemPayload) (string, adapter.ToolResult, bool
 		return "", adapter.ToolResult{}, false
 	}
 	output := adapter.ContentToString(payload.Output)
+	failed, known := commandOutputStatus(output)
 	return payload.CallID, adapter.ToolResult{
-		Content: output,
-		IsError: commandOutputFailed(output),
+		Content:      output,
+		IsError:      failed,
+		OutcomeKnown: known,
 	}, true
 }
 
@@ -719,7 +722,7 @@ func applyPatchChanges(input map[string]any, changes map[string]patchApplyChange
 
 var exitCodeRe = regexp.MustCompile(`(?im)^(?:Process exited with code|Exit code:)\s*([0-9]+)\s*$`)
 
-func commandOutputFailed(output string) bool {
+func commandOutputStatus(output string) (failed bool, known bool) {
 	trimmed := strings.TrimSpace(output)
 	var envelope struct {
 		ExitCode *int  `json:"exit_code"`
@@ -730,17 +733,17 @@ func commandOutputFailed(output string) bool {
 	}
 	if json.Unmarshal([]byte(trimmed), &envelope) == nil {
 		if envelope.ExitCode != nil {
-			return *envelope.ExitCode != 0
+			return *envelope.ExitCode != 0, true
 		}
 		if envelope.Metadata.ExitCode != nil {
-			return *envelope.Metadata.ExitCode != 0
+			return *envelope.Metadata.ExitCode != 0, true
 		}
 		if envelope.TimedOut != nil && *envelope.TimedOut {
-			return true
+			return true, true
 		}
 	}
 	if strings.HasPrefix(strings.ToLower(trimmed), "apply_patch verification failed") {
-		return true
+		return true, true
 	}
 	firstLine := trimmed
 	if newline := strings.IndexByte(firstLine, '\n'); newline >= 0 {
@@ -748,10 +751,12 @@ func commandOutputFailed(output string) bool {
 	}
 	status := strings.ToLower(strings.TrimSpace(firstLine))
 	switch {
-	case strings.HasPrefix(status, "script completed"), strings.HasPrefix(status, "script running"):
-		return false
+	case strings.HasPrefix(status, "script completed"):
+		return false, true
 	case strings.HasPrefix(status, "script failed"):
-		return true
+		return true, true
+	case strings.HasPrefix(status, "script running"):
+		return false, false
 	}
 	header := trimmed
 	for _, marker := range []string{"\nOutput:\n", "\nFinal output:\n"} {
@@ -761,11 +766,14 @@ func commandOutputFailed(output string) bool {
 	}
 	for _, line := range strings.Split(header, "\n") {
 		if strings.EqualFold(strings.TrimSpace(line), "aborted by user") {
-			return true
+			return true, true
 		}
 	}
 	match := exitCodeRe.FindStringSubmatch(header)
-	return len(match) == 2 && match[1] != "0"
+	if len(match) == 2 {
+		return match[1] != "0", true
+	}
+	return false, false
 }
 
 func (a Adapter) titleFor(id string) string {

--- a/internal/adapter/codex/adapter_test.go
+++ b/internal/adapter/codex/adapter_test.go
@@ -406,30 +406,32 @@ func TestParseCodexJSRepl(t *testing.T) {
 	}
 }
 
-func TestCommandOutputFailedVariants(t *testing.T) {
+func TestCommandOutputStatus(t *testing.T) {
 	tests := []struct {
-		output string
-		want   bool
+		output     string
+		wantFailed bool
+		wantKnown  bool
 	}{
-		{output: "Process exited with code 1", want: true},
-		{output: "Exit code: 2", want: true},
-		{output: `{"output":"ok","metadata":{"exit_code":0}}`, want: false},
-		{output: `{"output":"failed","metadata":{"exit_code":1}}`, want: true},
-		{output: `{"output":"failed","exit_code":3}`, want: true},
-		{output: `{"output":"Exit code: 1","metadata":{"exit_code":0}}`, want: false},
-		{output: "Script completed\nWall time 0.1 seconds\nOutput:\nExit code: 1", want: false},
-		{output: "Script running with cell ID 28\nExit code: 1", want: false},
-		{output: "Script failed\nExit code: 0", want: true},
-		{output: "plain output", want: false},
-		{output: `{"message":"Wait timed out after 20000ms","timed_out":true}`, want: true},
-		{output: `{"message":"still running","timed_out":false}`, want: false},
-		{output: "apply_patch verification failed: Failed to find expected lines in a.go", want: true},
-		{output: "Wall time: 8.9 seconds\naborted by user", want: true},
-		{output: "Wall time: 8.9 seconds\nOutput:\naborted by user", want: false},
+		{output: "Process exited with code 1", wantFailed: true, wantKnown: true},
+		{output: "Exit code: 2", wantFailed: true, wantKnown: true},
+		{output: `{"output":"ok","metadata":{"exit_code":0}}`, wantKnown: true},
+		{output: `{"output":"failed","metadata":{"exit_code":1}}`, wantFailed: true, wantKnown: true},
+		{output: `{"output":"failed","exit_code":3}`, wantFailed: true, wantKnown: true},
+		{output: `{"output":"Exit code: 1","metadata":{"exit_code":0}}`, wantKnown: true},
+		{output: "Script completed\nWall time 0.1 seconds\nOutput:\nExit code: 1", wantKnown: true},
+		{output: "Script running with cell ID 28\nExit code: 1"},
+		{output: "Script failed\nExit code: 0", wantFailed: true, wantKnown: true},
+		{output: "plain output"},
+		{output: `{"message":"Wait timed out after 20000ms","timed_out":true}`, wantFailed: true, wantKnown: true},
+		{output: `{"message":"still running","timed_out":false}`},
+		{output: "apply_patch verification failed: Failed to find expected lines in a.go", wantFailed: true, wantKnown: true},
+		{output: "Wall time: 8.9 seconds\naborted by user", wantFailed: true, wantKnown: true},
+		{output: "Wall time: 8.9 seconds\nOutput:\naborted by user"},
 	}
 	for _, tt := range tests {
-		if got := commandOutputFailed(tt.output); got != tt.want {
-			t.Errorf("commandOutputFailed(%q) = %v, want %v", tt.output, got, tt.want)
+		failed, known := commandOutputStatus(tt.output)
+		if failed != tt.wantFailed || known != tt.wantKnown {
+			t.Errorf("commandOutputStatus(%q) = (%v, %v), want (%v, %v)", tt.output, failed, known, tt.wantFailed, tt.wantKnown)
 		}
 	}
 }

--- a/internal/adapter/codex/adapter_test.go
+++ b/internal/adapter/codex/adapter_test.go
@@ -417,22 +417,78 @@ func TestCommandOutputStatus(t *testing.T) {
 		{output: `{"output":"ok","metadata":{"exit_code":0}}`, wantKnown: true},
 		{output: `{"output":"failed","metadata":{"exit_code":1}}`, wantFailed: true, wantKnown: true},
 		{output: `{"output":"failed","exit_code":3}`, wantFailed: true, wantKnown: true},
+		{output: `{"exit_code":3}`},
+		{output: `{"output":"failed","Exit_Code":3}`},
+		{output: `{"output":"failed","metadata":{"Exit_Code":1}}`},
 		{output: `{"output":"Exit code: 1","metadata":{"exit_code":0}}`, wantKnown: true},
 		{output: "Script completed\nWall time 0.1 seconds\nOutput:\nExit code: 1", wantKnown: true},
 		{output: "Script running with cell ID 28\nExit code: 1"},
 		{output: "Script failed\nExit code: 0", wantFailed: true, wantKnown: true},
 		{output: "plain output"},
 		{output: `{"message":"Wait timed out after 20000ms","timed_out":true}`, wantFailed: true, wantKnown: true},
+		{output: `{"message":"Wait timed out after 20000ms","Timed_Out":true}`},
 		{output: `{"message":"still running","timed_out":false}`},
-		{output: "apply_patch verification failed: Failed to find expected lines in a.go", wantFailed: true, wantKnown: true},
+		{output: "apply_patch verification failed: Failed to find expected lines in a.go"},
 		{output: "Wall time: 8.9 seconds\naborted by user", wantFailed: true, wantKnown: true},
 		{output: "Wall time: 8.9 seconds\nOutput:\naborted by user"},
+		{output: "Script completedly\nWall time 0.1 seconds"},
 	}
 	for _, tt := range tests {
 		failed, known := commandOutputStatus(tt.output)
 		if failed != tt.wantFailed || known != tt.wantKnown {
 			t.Errorf("commandOutputStatus(%q) = (%v, %v), want (%v, %v)", tt.output, failed, known, tt.wantFailed, tt.wantKnown)
 		}
+	}
+}
+
+func TestParseCodexScopesOutcomeInferenceAndMatchesExactKeys(t *testing.T) {
+	session := filepath.Join(t.TempDir(), "outcome-scope.jsonl")
+	writeJSONL(t, session,
+		map[string]any{
+			"timestamp": "2026-07-10T00:00:00Z",
+			"type":      "session_meta",
+			"payload":   map[string]any{"id": "outcome-scope", "cwd": filepath.ToSlash(t.TempDir())},
+		},
+		customCall("2026-07-10T00:00:01Z", "ctc-script", "call-script", "view_image", map[string]any{"path": "image.png"}),
+		customOutput("2026-07-10T00:00:02Z", "call-script", "Script completed\nWall time 0.1 seconds"),
+		customCall("2026-07-10T00:00:03Z", "ctc-json", "call-json", "view_image", map[string]any{"path": "image.png"}),
+		customOutput("2026-07-10T00:00:04Z", "call-json", `{"output":"failed","exit_code":1}`),
+		call("2026-07-10T00:00:05Z", "fc-wrong", "call-wrong", "exec_command", map[string]any{"cmd": "false"}),
+		output("2026-07-10T00:00:06Z", "call-wrong", `{"output":"failed","Exit_Code":1}`),
+		customCall("2026-07-10T00:00:07Z", "ctc-exact", "call-exact", "exec", `text(await tools.exec_command({cmd: "false"}))`),
+		customOutput("2026-07-10T00:00:08Z", "call-exact", `{"output":"failed","exit_code":1}`),
+		customCall("2026-07-10T00:00:09Z", "ctc-patch", "call-patch", "apply_patch", "*** Begin Patch\n*** Add File: added.go\n*** End Patch\n"),
+		customOutput("2026-07-10T00:00:10Z", "call-patch", "plain output"),
+		map[string]any{
+			"timestamp": "2026-07-10T00:00:11Z",
+			"type":      "event_msg",
+			"payload": map[string]any{
+				"type":    "patch_apply_end",
+				"call_id": "call-patch",
+				"Success": true,
+			},
+		},
+		customCall("2026-07-10T00:00:12Z", "ctc-patch-fail", "call-patch-fail", "apply_patch", "*** Begin Patch\n*** Update File: missing.go\n*** End Patch\n"),
+		customOutput("2026-07-10T00:00:13Z", "call-patch-fail", "apply_patch verification failed: missing.go"),
+	)
+
+	trace, err := (Adapter{}).Parse(session)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(trace.Events) != 6 {
+		t.Fatalf("events = %#v", trace.Events)
+	}
+	for _, index := range []int{0, 1, 2, 4} {
+		if got := trace.Events[index]; got.OutcomeKnown || got.IsError {
+			t.Fatalf("event %d promoted to known outcome: %#v", index, got)
+		}
+	}
+	if got := trace.Events[3]; !got.OutcomeKnown || !got.IsError {
+		t.Fatalf("exact command envelope = %#v", got)
+	}
+	if got := trace.Events[5]; !got.OutcomeKnown || !got.IsError {
+		t.Fatalf("apply_patch failure = %#v", got)
 	}
 }
 

--- a/internal/adapter/pi/adapter.go
+++ b/internal/adapter/pi/adapter.go
@@ -103,8 +103,8 @@ func (a Adapter) Summarize(path string) (model.SessionMeta, error) {
 				meta.Model = entry.ModelID
 			}
 		case "message":
-			var msg piMessage
-			if json.Unmarshal(entry.Message, &msg) != nil {
+			msg, err := decodePiMessage(entry.Message)
+			if err != nil {
 				continue
 			}
 			switch msg.Role {
@@ -191,8 +191,8 @@ func (a Adapter) Parse(path string) (*model.Trace, error) {
 			// it as a user turn in ComputeStats, so it is dropped the same
 			// way injected user messages are.
 		case "message":
-			var msg piMessage
-			if json.Unmarshal(entry.Message, &msg) != nil {
+			msg, err := decodePiMessage(entry.Message)
+			if err != nil {
 				continue
 			}
 			switch msg.Role {
@@ -330,6 +330,34 @@ type piMessage struct {
 	Command    string          `json:"command"`
 	Output     string          `json:"output"`
 	ExitCode   *int            `json:"exitCode"`
+}
+
+func decodePiMessage(data json.RawMessage) (piMessage, error) {
+	var msg piMessage
+	if err := json.Unmarshal(data, &msg); err != nil {
+		return piMessage{}, err
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(data, &fields); err != nil {
+		return piMessage{}, err
+	}
+	msg.IsError = nil
+	if raw, ok := fields["isError"]; ok && strings.TrimSpace(string(raw)) != "null" {
+		var value bool
+		if err := json.Unmarshal(raw, &value); err != nil {
+			return piMessage{}, err
+		}
+		msg.IsError = &value
+	}
+	msg.ExitCode = nil
+	if raw, ok := fields["exitCode"]; ok && strings.TrimSpace(string(raw)) != "null" {
+		var value int
+		if err := json.Unmarshal(raw, &value); err != nil {
+			return piMessage{}, err
+		}
+		msg.ExitCode = &value
+	}
+	return msg, nil
 }
 
 type contentBlock struct {

--- a/internal/adapter/pi/adapter.go
+++ b/internal/adapter/pi/adapter.go
@@ -233,9 +233,11 @@ func (a Adapter) Parse(path string) (*model.Trace, error) {
 					continue
 				}
 				delete(pending, msg.ToolCallID)
+				isError := msg.IsError != nil && *msg.IsError
 				trace.Events = append(trace.Events, adapter.BuildEvent(trace, call, adapter.ToolResult{
-					Content: contentText(msg.Content),
-					IsError: msg.IsError,
+					Content:      contentText(msg.Content),
+					IsError:      isError,
+					OutcomeKnown: msg.IsError != nil,
 				}))
 			case "bashExecution":
 				// A `!` command the user ran from the TUI still touches the
@@ -246,8 +248,9 @@ func (a Adapter) Parse(path string) (*model.Trace, error) {
 					Timestamp: entry.Timestamp,
 				}
 				trace.Events = append(trace.Events, adapter.BuildEvent(trace, call, adapter.ToolResult{
-					Content: msg.Output,
-					IsError: msg.ExitCode != nil && *msg.ExitCode != 0,
+					Content:      msg.Output,
+					IsError:      msg.ExitCode != nil && *msg.ExitCode != 0,
+					OutcomeKnown: msg.ExitCode != nil,
 				}))
 			}
 		}
@@ -323,7 +326,7 @@ type piMessage struct {
 	Content    json.RawMessage `json:"content"`
 	Model      string          `json:"model"`
 	ToolCallID string          `json:"toolCallId"`
-	IsError    bool            `json:"isError"`
+	IsError    *bool           `json:"isError"`
 	Command    string          `json:"command"`
 	Output     string          `json:"output"`
 	ExitCode   *int            `json:"exitCode"`

--- a/internal/adapter/pi/adapter_test.go
+++ b/internal/adapter/pi/adapter_test.go
@@ -79,6 +79,34 @@ func TestParseLinearSession(t *testing.T) {
 	}
 }
 
+func TestParsePreservesToolOutcomeCertainty(t *testing.T) {
+	root := t.TempDir()
+	path := writeSession(t,
+		header(root),
+		`{"type":"message","id":"a1","parentId":null,"timestamp":"2026-07-21T14:35:01.000Z","message":{"role":"assistant","content":[{"type":"toolCall","id":"success","name":"read","arguments":{"path":"ok.go"}},{"type":"toolCall","id":"failure","name":"edit","arguments":{"path":"bad.go"}},{"type":"toolCall","id":"unknown","name":"bash","arguments":{"command":"sleep 100"}}],"stopReason":"toolUse"}}`,
+		`{"type":"message","id":"r1","parentId":"a1","timestamp":"2026-07-21T14:35:02.000Z","message":{"role":"toolResult","toolCallId":"success","toolName":"read","content":[{"type":"text","text":"ok"}],"isError":false}}`,
+		`{"type":"message","id":"r2","parentId":"r1","timestamp":"2026-07-21T14:35:03.000Z","message":{"role":"toolResult","toolCallId":"failure","toolName":"edit","content":[{"type":"text","text":"failed"}],"isError":true}}`,
+		`{"type":"message","id":"r3","parentId":"r2","timestamp":"2026-07-21T14:35:04.000Z","message":{"role":"toolResult","toolCallId":"unknown","toolName":"bash","content":[{"type":"text","text":"still running"}]}}`,
+	)
+
+	trace, err := (Adapter{}).Parse(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(trace.Events) != 3 {
+		t.Fatalf("events = %#v", trace.Events)
+	}
+	if got := trace.Events[0]; !got.OutcomeKnown || got.IsError {
+		t.Fatalf("success event = %#v", got)
+	}
+	if got := trace.Events[1]; !got.OutcomeKnown || !got.IsError {
+		t.Fatalf("failure event = %#v", got)
+	}
+	if got := trace.Events[2]; got.OutcomeKnown || got.IsError {
+		t.Fatalf("unknown event = %#v", got)
+	}
+}
+
 func TestParseFollowsTrunkAcrossBranches(t *testing.T) {
 	root := t.TempDir()
 	fileA := filepath.Join(root, "a.go")
@@ -187,14 +215,14 @@ func TestParseBashExecution(t *testing.T) {
 	if len(trace.Events) != 3 {
 		t.Fatalf("events = %#v", trace.Events)
 	}
-	if trace.Events[0].Tool != "bash" || !trace.Events[0].IsError {
+	if trace.Events[0].Tool != "bash" || !trace.Events[0].OutcomeKnown || !trace.Events[0].IsError {
 		t.Fatalf("failed command event = %#v", trace.Events[0])
 	}
-	if trace.Events[1].Action != "verify" || trace.Events[1].IsError {
+	if trace.Events[1].Action != "verify" || !trace.Events[1].OutcomeKnown || trace.Events[1].IsError {
 		t.Fatalf("verify event = %#v", trace.Events[1])
 	}
-	if trace.Events[2].IsError {
-		t.Fatalf("cancelled command without exit code is not an error: %#v", trace.Events[2])
+	if trace.Events[2].OutcomeKnown || trace.Events[2].IsError {
+		t.Fatalf("cancelled command without exit code has unknown outcome: %#v", trace.Events[2])
 	}
 }
 

--- a/internal/adapter/pi/adapter_test.go
+++ b/internal/adapter/pi/adapter_test.go
@@ -83,17 +83,18 @@ func TestParsePreservesToolOutcomeCertainty(t *testing.T) {
 	root := t.TempDir()
 	path := writeSession(t,
 		header(root),
-		`{"type":"message","id":"a1","parentId":null,"timestamp":"2026-07-21T14:35:01.000Z","message":{"role":"assistant","content":[{"type":"toolCall","id":"success","name":"read","arguments":{"path":"ok.go"}},{"type":"toolCall","id":"failure","name":"edit","arguments":{"path":"bad.go"}},{"type":"toolCall","id":"unknown","name":"bash","arguments":{"command":"sleep 100"}}],"stopReason":"toolUse"}}`,
+		`{"type":"message","id":"a1","parentId":null,"timestamp":"2026-07-21T14:35:01.000Z","message":{"role":"assistant","content":[{"type":"toolCall","id":"success","name":"read","arguments":{"path":"ok.go"}},{"type":"toolCall","id":"failure","name":"edit","arguments":{"path":"bad.go"}},{"type":"toolCall","id":"unknown","name":"bash","arguments":{"command":"sleep 100"}},{"type":"toolCall","id":"wrong-case","name":"edit","arguments":{"path":"case.go"}}],"stopReason":"toolUse"}}`,
 		`{"type":"message","id":"r1","parentId":"a1","timestamp":"2026-07-21T14:35:02.000Z","message":{"role":"toolResult","toolCallId":"success","toolName":"read","content":[{"type":"text","text":"ok"}],"isError":false}}`,
 		`{"type":"message","id":"r2","parentId":"r1","timestamp":"2026-07-21T14:35:03.000Z","message":{"role":"toolResult","toolCallId":"failure","toolName":"edit","content":[{"type":"text","text":"failed"}],"isError":true}}`,
 		`{"type":"message","id":"r3","parentId":"r2","timestamp":"2026-07-21T14:35:04.000Z","message":{"role":"toolResult","toolCallId":"unknown","toolName":"bash","content":[{"type":"text","text":"still running"}]}}`,
+		`{"type":"message","id":"r4","parentId":"r3","timestamp":"2026-07-21T14:35:05.000Z","message":{"role":"toolResult","toolCallId":"wrong-case","toolName":"edit","content":[{"type":"text","text":"ok"}],"IsError":true}}`,
 	)
 
 	trace, err := (Adapter{}).Parse(path)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(trace.Events) != 3 {
+	if len(trace.Events) != 4 {
 		t.Fatalf("events = %#v", trace.Events)
 	}
 	if got := trace.Events[0]; !got.OutcomeKnown || got.IsError {
@@ -104,6 +105,12 @@ func TestParsePreservesToolOutcomeCertainty(t *testing.T) {
 	}
 	if got := trace.Events[2]; got.OutcomeKnown || got.IsError {
 		t.Fatalf("unknown event = %#v", got)
+	}
+	if got := trace.Events[3]; got.OutcomeKnown || got.IsError {
+		t.Fatalf("wrong-case error key event = %#v", got)
+	}
+	if trace.Stats.Observability.Errors != "estimated" {
+		t.Fatalf("observability = %#v", trace.Stats.Observability)
 	}
 }
 
@@ -206,13 +213,14 @@ func TestParseBashExecution(t *testing.T) {
 		`{"type":"message","id":"e1","parentId":null,"timestamp":"2026-07-21T14:35:00.000Z","message":{"role":"bashExecution","command":"npm run build","output":"boom","exitCode":1,"cancelled":false,"truncated":false,"timestamp":1}}`,
 		`{"type":"message","id":"e2","parentId":"e1","timestamp":"2026-07-21T14:35:10.000Z","message":{"role":"bashExecution","command":"go test ./...","output":"ok","exitCode":0,"cancelled":false,"truncated":false,"timestamp":2}}`,
 		`{"type":"message","id":"e3","parentId":"e2","timestamp":"2026-07-21T14:35:20.000Z","message":{"role":"bashExecution","command":"sleep 100","output":"","cancelled":true,"truncated":false,"timestamp":3}}`,
+		`{"type":"message","id":"e4","parentId":"e3","timestamp":"2026-07-21T14:35:30.000Z","message":{"role":"bashExecution","command":"false","output":"boom","ExitCode":1,"cancelled":false,"truncated":false,"timestamp":4}}`,
 	)
 
 	trace, err := Adapter{}.Parse(path)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(trace.Events) != 3 {
+	if len(trace.Events) != 4 {
 		t.Fatalf("events = %#v", trace.Events)
 	}
 	if trace.Events[0].Tool != "bash" || !trace.Events[0].OutcomeKnown || !trace.Events[0].IsError {
@@ -223,6 +231,9 @@ func TestParseBashExecution(t *testing.T) {
 	}
 	if trace.Events[2].OutcomeKnown || trace.Events[2].IsError {
 		t.Fatalf("cancelled command without exit code has unknown outcome: %#v", trace.Events[2])
+	}
+	if trace.Events[3].OutcomeKnown || trace.Events[3].IsError {
+		t.Fatalf("wrong-case exit code has unknown outcome: %#v", trace.Events[3])
 	}
 }
 

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -79,7 +79,10 @@ type Event struct {
 	Outside     []OutsideTouch `json:"outside,omitempty"`
 	ResultBytes int            `json:"resultBytes"`
 	IsError     bool           `json:"isError"`
-	Summary     string         `json:"summary"`
+	// OutcomeKnown distinguishes a recorded success from an unknown non-error
+	// result. IsError remains sufficient to identify failures in older traces.
+	OutcomeKnown bool   `json:"outcomeKnown,omitempty"`
+	Summary      string `json:"summary"`
 }
 
 type Target struct {

--- a/internal/model/stats.go
+++ b/internal/model/stats.go
@@ -12,6 +12,7 @@ func ComputeStats(trace *Trace, filesInRepo int, errorSignal string) Stats {
 	weakReads := 0
 	repeatedReads := 0
 	errors := 0
+	unknownOutcomes := false
 	firstEdit := -1
 
 	stats := Stats{FilesInRepo: filesInRepo}
@@ -21,6 +22,8 @@ func ComputeStats(trace *Trace, filesInRepo int, errorSignal string) Stats {
 		if event.IsError {
 			errors++
 			countAction(&stats.Errors, event.Action)
+		} else if !event.OutcomeKnown {
+			unknownOutcomes = true
 		}
 		stats.ResultBytes += int64(event.ResultBytes)
 		switch event.Action {
@@ -108,6 +111,9 @@ func ComputeStats(trace *Trace, filesInRepo int, errorSignal string) Stats {
 		stats.Observability.Reads = ObservabilityEstimated
 	}
 	if errorSignal == "" {
+		errorSignal = ObservabilityEstimated
+	}
+	if errorSignal == ObservabilityExact && unknownOutcomes {
 		errorSignal = ObservabilityEstimated
 	}
 	stats.Observability.Errors = errorSignal

--- a/internal/model/stats_test.go
+++ b/internal/model/stats_test.go
@@ -57,9 +57,11 @@ func TestComputeStatsEditsAfterLastVerifyWithoutVerify(t *testing.T) {
 }
 
 func TestComputeStatsObservability(t *testing.T) {
-	strongRead := Event{Action: "read", Targets: []Target{{Path: "a.go", Touch: "read"}}}
-	weakRead := Event{Action: "read", Targets: []Target{{Path: "b.go", Touch: "read", Weak: true}}}
+	strongRead := Event{Action: "read", OutcomeKnown: true, Targets: []Target{{Path: "a.go", Touch: "read"}}}
+	weakRead := Event{Action: "read", OutcomeKnown: true, Targets: []Target{{Path: "b.go", Touch: "read", Weak: true}}}
 	hitOnly := Event{Action: "search", Targets: []Target{{Path: "c.go", Touch: "hit"}}}
+	pending := Event{Action: "exec"}
+	legacyFailure := Event{Action: "exec", IsError: true}
 
 	tests := []struct {
 		name        string
@@ -70,6 +72,8 @@ func TestComputeStatsObservability(t *testing.T) {
 	}{
 		{"strong reads are exact", []Event{strongRead}, ObservabilityExact, ObservabilityExact, ObservabilityExact},
 		{"any weak read downgrades", []Event{strongRead, weakRead}, ObservabilityExact, ObservabilityEstimated, ObservabilityExact},
+		{"unknown outcome downgrades exact errors", []Event{strongRead, pending}, ObservabilityExact, ObservabilityExact, ObservabilityEstimated},
+		{"legacy failure remains known", []Event{legacyFailure}, ObservabilityExact, ObservabilityUnavailable, ObservabilityExact},
 		{"no reads is unavailable", []Event{hitOnly}, ObservabilityEstimated, ObservabilityUnavailable, ObservabilityEstimated},
 		{"empty error signal falls back to estimated", []Event{strongRead}, "", ObservabilityExact, ObservabilityEstimated},
 	}

--- a/internal/model/trace_schema_test.go
+++ b/internal/model/trace_schema_test.go
@@ -1,0 +1,67 @@
+package model
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/santhosh-tekuri/jsonschema/v6"
+)
+
+func TestTraceSchemaAcceptsOutcomeCertainty(t *testing.T) {
+	trace := Trace{
+		Version: 1,
+		Session: TraceSession{
+			ID:         "session",
+			Harness:    "codex",
+			EventCount: 3,
+		},
+		Events: []Event{
+			{
+				Seq:          0,
+				Tool:         "exec_command",
+				Action:       "verify",
+				Targets:      []Target{},
+				OutcomeKnown: true,
+				Summary:      "run tests",
+			},
+			{
+				Seq:          1,
+				Tool:         "exec_command",
+				Action:       "verify",
+				Targets:      []Target{},
+				IsError:      true,
+				OutcomeKnown: true,
+				Summary:      "tests failed",
+			},
+			{
+				Seq:     2,
+				Tool:    "exec_command",
+				Action:  "exec",
+				Targets: []Target{},
+				Summary: "still running",
+			},
+		},
+		Marks: []Mark{},
+		Stats: ComputeStats(&Trace{}, 0, ObservabilityEstimated),
+	}
+	document, err := json.Marshal(trace)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var value any
+	if err := json.Unmarshal(document, &value); err != nil {
+		t.Fatal(err)
+	}
+	events := value.(map[string]any)["events"].([]any)
+	if _, found := events[2].(map[string]any)["outcomeKnown"]; found {
+		t.Fatal("unknown outcome serialized outcomeKnown")
+	}
+	compiler := jsonschema.NewCompiler()
+	schema, err := compiler.Compile("../../schema/trace.schema.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := schema.Validate(value); err != nil {
+		t.Fatalf("trace with outcome certainty violates schema: %v\n%s", err, document)
+	}
+}

--- a/schema/trace.schema.json
+++ b/schema/trace.schema.json
@@ -51,6 +51,7 @@
           },
           "resultBytes": { "type": "integer", "minimum": 0 },
           "isError": { "type": "boolean" },
+          "outcomeKnown": { "type": "boolean" },
           "summary": { "type": "string" }
         },
         "additionalProperties": false

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -142,6 +142,7 @@ export interface TraceEvent {
   outside?: OutsideTouch[];
   resultBytes: number;
   isError: boolean;
+  outcomeKnown?: boolean;
   summary: string;
 }
 


### PR DESCRIPTION
## Why

A normalized event currently exposes only `isError`. When it is `false`, consumers cannot tell whether the tool definitely succeeded or the source log never recorded a final outcome.

This extracts the adapter/data-layer part of #14 so mindwalk can preserve that distinction without committing to a Trace Health UI or product contract.

## What changed

- Add optional `outcomeKnown` evidence to normalized trace events.
- Preserve Claude Code's explicit `is_error: false` versus a missing `is_error` field.
- Parse Codex command output into known success, known failure, or unknown.
- Treat structured Codex `patch_apply_end.success` as a known outcome.
- Keep the trace schema and TypeScript contract mirror in sync.

The resulting states are:

| `outcomeKnown` | `isError` | Meaning |
| --- | --- | --- |
| `true` | `false` | known success |
| `true` | `true` | known failure |
| absent / `false` | `false` | outcome unknown |

`outcomeKnown` is optional, so traces produced before this change remain valid under the updated schema. Existing `isError: true` events still identify failures without the new field.

## Scope

This PR intentionally does not include session-health derivation, a health API or CLI command, or any UI. It only preserves source evidence in the shared trace model for future consumers such as judge input, comparisons, or metric annotations.

## Validation

- `go test -count=1 ./...`
- `go vet ./...`
- `make test`
- `mindwalk trace testdata/claude-session.jsonl` smoke check confirmed `outcomeKnown: true` in exported events

Related to #14.
