### PR TITLE
server: component boundaries — traceStore, adapter sidecar interface, report index, loopback hardening

### DIFF
--- a/cmd/mindwalk/main.go
+++ b/cmd/mindwalk/main.go
@@ -192,7 +192,7 @@ func analyze(args []string) error {
 		// A rubric-enabled request is only answered from cache when the report
 		// already settles the rubric question; a rubric-less fresh report gets
 		// re-run rather than silently returned without the layer.
-		if judge.Fresh(cached, tr) && judgeMatches(cached, *judgeCLI, *judgeModel) &&
+		if judge.FreshAgainstTrace(cached, tr) && judgeMatches(cached, *judgeCLI, *judgeModel) &&
 			judge.RubricSatisfied(cached) {
 			fmt.Fprintln(os.Stderr, "mindwalk: using cached report (pass --no-cache to re-run)")
 			return writeJSON(*out, cached)

--- a/internal/adapter/adapter.go
+++ b/internal/adapter/adapter.go
@@ -30,6 +30,14 @@ type AgentGraphSource interface {
 	BuildAgentGraph(root model.SessionMeta, catalog []model.SessionMeta) (*model.AgentGraph, error)
 }
 
+// SummarySidecarSource lists companion files whose contents feed Summarize
+// for a session path. Which files a harness keeps beside its session logs is
+// adapter knowledge; callers only fingerprint the returned paths to decide
+// whether a cached summary is still valid.
+type SummarySidecarSource interface {
+	SummaryInputs(path string) []string
+}
+
 type ToolCall struct {
 	ID        string
 	Name      string

--- a/internal/adapter/claudecode/adapter.go
+++ b/internal/adapter/claudecode/adapter.go
@@ -66,6 +66,16 @@ func (a Adapter) ListSessions() ([]model.SessionMeta, error) {
 	return metas, nil
 }
 
+// SummaryInputs reports the sidecar files Summarize reads for path: child
+// agent sessions carry an agent-*.meta.json describing the spawning tool
+// call, so a sidecar change must invalidate a cached summary.
+func (a Adapter) SummaryInputs(path string) []string {
+	if !strings.HasPrefix(filepath.Base(path), "agent-") {
+		return nil
+	}
+	return []string{strings.TrimSuffix(path, ".jsonl") + ".meta.json"}
+}
+
 func (a Adapter) Summarize(path string) (model.SessionMeta, error) {
 	f, err := os.Open(path)
 	if err != nil {

--- a/internal/adapter/claudecode/summary_inputs_test.go
+++ b/internal/adapter/claudecode/summary_inputs_test.go
@@ -1,0 +1,19 @@
+package claudecode
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestSummaryInputsDeclaresAgentSidecarOnly(t *testing.T) {
+	a := Adapter{}
+	child := filepath.Join("proj", "agent-abc.jsonl")
+	inputs := a.SummaryInputs(child)
+	want := filepath.Join("proj", "agent-abc.meta.json")
+	if len(inputs) != 1 || inputs[0] != want {
+		t.Fatalf("SummaryInputs(%q) = %v, want [%s]", child, inputs, want)
+	}
+	if inputs := a.SummaryInputs(filepath.Join("proj", "root.jsonl")); inputs != nil {
+		t.Fatalf("main session declared sidecars: %v", inputs)
+	}
+}

--- a/internal/adapter/codex/adapter.go
+++ b/internal/adapter/codex/adapter.go
@@ -79,6 +79,26 @@ func (a Adapter) ListSessions() ([]model.SessionMeta, error) {
 	return metas, nil
 }
 
+// SummaryInputs reports the sidecar files Summarize reads for a session:
+// titles come from a session_index.jsonl resolved next to the sessions
+// directory or at the default location, so an index change — a Codex thread
+// rename — must invalidate cached summaries. Candidates are declared even
+// while missing (unlike indexPath, which stat-gates), so creating the index
+// later invalidates too.
+func (a Adapter) SummaryInputs(_ string) []string {
+	if a.IndexPath != "" {
+		return []string{a.IndexPath}
+	}
+	var inputs []string
+	if dir := filepath.Clean(a.SessionDir()); dir != "" && dir != "." {
+		inputs = append(inputs, filepath.Join(filepath.Dir(dir), "session_index.jsonl"))
+	}
+	if candidate := DefaultIndexPath(); candidate != "" && (len(inputs) == 0 || inputs[0] != candidate) {
+		inputs = append(inputs, candidate)
+	}
+	return inputs
+}
+
 func (a Adapter) Summarize(path string) (model.SessionMeta, error) {
 	f, err := os.Open(path)
 	if err != nil {

--- a/internal/adapter/codex/summary_inputs_test.go
+++ b/internal/adapter/codex/summary_inputs_test.go
@@ -1,0 +1,20 @@
+package codex
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestSummaryInputsDeclaresTitleIndex(t *testing.T) {
+	a := Adapter{Dir: filepath.Join("root", "sessions")}
+	inputs := a.SummaryInputs("any.jsonl")
+	want := filepath.Join("root", "session_index.jsonl")
+	if len(inputs) == 0 || inputs[0] != want {
+		t.Fatalf("SummaryInputs = %v, want first candidate %s", inputs, want)
+	}
+
+	override := Adapter{Dir: "root", IndexPath: filepath.Join("custom", "idx.jsonl")}
+	if inputs := override.SummaryInputs("any.jsonl"); len(inputs) != 1 || inputs[0] != override.IndexPath {
+		t.Fatalf("IndexPath override not honored: %v", inputs)
+	}
+}

--- a/internal/judge/cache.go
+++ b/internal/judge/cache.go
@@ -28,6 +28,12 @@ func (c Cache) path(sessionKey string) string {
 	return filepath.Join(c.Dir, sessionKey+".json")
 }
 
+// Path returns the on-disk location of the session's report file, for
+// callers that fingerprint reports without loading them.
+func (c Cache) Path(sessionKey string) string {
+	return c.path(sessionKey)
+}
+
 // Load returns the cached report for the session key, or nil when absent or
 // unreadable (a corrupt cache entry is treated as a miss, not an error).
 func (c Cache) Load(sessionKey string) *model.Report {
@@ -68,20 +74,37 @@ func (c Cache) Load(sessionKey string) *model.Report {
 	return &report
 }
 
-// Fresh reports whether a cached report still matches the trace it would be
-// regenerated from: same prompt version and the same judge input digest —
-// event counts alone miss user messages (stored as marks) and content edits.
-// The rubric layer is checked against the current task evidence separately,
-// because its input window is wider than the scoring document's. The judge
-// CLI is deliberately not part of freshness — a valid report stays valid.
-// Reports from before the digest existed are stale by construction.
-func Fresh(report *model.Report, trace *model.Trace) bool {
+// FreshAgainstTrace reports whether a cached report still matches the trace
+// it would be regenerated from: same prompt version and the same judge input
+// digest — event counts alone miss user messages (stored as marks) and
+// content edits. The rubric layer is checked against the current task
+// evidence separately, because its input window is wider than the scoring
+// document's. The judge CLI is deliberately not part of freshness — a valid
+// report stays valid. Reports from before the digest existed are stale by
+// construction.
+func FreshAgainstTrace(report *model.Report, trace *model.Trace) bool {
 	if report == nil ||
 		report.Judge.PromptVersion != PromptVersion ||
 		report.Judge.InputDigest != InputDigest(trace) {
 		return false
 	}
 	return rubricFresh(report, trace)
+}
+
+// FreshAgainstSummary is the cheap approximation of FreshAgainstTrace for
+// callers holding only a session summary (the list view): it shares the
+// prompt-version and digest-presence preconditions but compares the
+// summary's event and user-turn counts instead of recomputing the input
+// digest, so no trace parse is needed. It may call a report fresh that
+// FreshAgainstTrace grades stale (a content edit that keeps both counts);
+// the panel's full check corrects that. User turns catch message-only
+// growth the event count is blind to.
+func FreshAgainstSummary(report *model.Report, meta model.SessionMeta) bool {
+	return report != nil &&
+		report.Judge.PromptVersion == PromptVersion &&
+		report.Judge.InputDigest != "" &&
+		report.Session.EventCount == meta.EventCount &&
+		report.Session.UserTurns == meta.UserTurns
 }
 
 // rubricFresh verifies the rubric layer against the CURRENT task evidence.

--- a/internal/judge/fresh_summary_test.go
+++ b/internal/judge/fresh_summary_test.go
@@ -1,0 +1,37 @@
+package judge
+
+import (
+	"testing"
+
+	"github.com/cosmtrek/mindwalk/internal/model"
+)
+
+func TestFreshAgainstSummary(t *testing.T) {
+	report := &model.Report{
+		Session: model.ReportSession{EventCount: 3, UserTurns: 2},
+		Judge:   model.ReportJudge{PromptVersion: PromptVersion, InputDigest: "d"},
+	}
+	meta := model.SessionMeta{EventCount: 3, UserTurns: 2}
+	if !FreshAgainstSummary(report, meta) {
+		t.Fatal("matching counts and current prompt graded stale")
+	}
+	if FreshAgainstSummary(report, model.SessionMeta{EventCount: 4, UserTurns: 2}) {
+		t.Fatal("event growth graded fresh")
+	}
+	if FreshAgainstSummary(report, model.SessionMeta{EventCount: 3, UserTurns: 3}) {
+		t.Fatal("message-only growth graded fresh")
+	}
+	noDigest := *report
+	noDigest.Judge.InputDigest = ""
+	if FreshAgainstSummary(&noDigest, meta) {
+		t.Fatal("pre-digest report graded fresh; the panel would disagree")
+	}
+	oldPrompt := *report
+	oldPrompt.Judge.PromptVersion = PromptVersion - 1
+	if FreshAgainstSummary(&oldPrompt, meta) {
+		t.Fatal("outdated prompt graded fresh")
+	}
+	if FreshAgainstSummary(nil, meta) {
+		t.Fatal("nil report graded fresh")
+	}
+}

--- a/internal/judge/judge_test.go
+++ b/internal/judge/judge_test.go
@@ -250,22 +250,22 @@ func TestCacheRoundTripAndFreshness(t *testing.T) {
 	if loaded == nil || loaded.Session.ID != "s1" {
 		t.Fatalf("loaded = %#v", loaded)
 	}
-	if !Fresh(loaded, trace) {
+	if !FreshAgainstTrace(loaded, trace) {
 		t.Fatal("expected fresh")
 	}
 	// A new user message lands in marks, not events: the count is unchanged
 	// but the judge input moved, so the report must go stale.
 	trace.Marks = append(trace.Marks, model.Mark{Seq: 3, Type: "user-message", Note: "不要修改代码"})
-	if Fresh(loaded, trace) {
+	if FreshAgainstTrace(loaded, trace) {
 		t.Fatal("expected stale after a new user message with no new events")
 	}
 	trace = sampleTrace()
 	trace.Events = append(trace.Events, model.Event{Seq: 3, Action: "edit", Summary: "Edit b.go"})
 	trace.Session.EventCount = 4
-	if Fresh(loaded, trace) {
+	if FreshAgainstTrace(loaded, trace) {
 		t.Fatal("expected stale after event growth")
 	}
-	if Fresh(&model.Report{Judge: model.ReportJudge{PromptVersion: PromptVersion}}, sampleTrace()) {
+	if FreshAgainstTrace(&model.Report{Judge: model.ReportJudge{PromptVersion: PromptVersion}}, sampleTrace()) {
 		t.Fatal("report without a digest must be stale")
 	}
 	if cache.Load("missing") != nil {

--- a/internal/judge/rubric_test.go
+++ b/internal/judge/rubric_test.go
@@ -497,32 +497,32 @@ func TestFreshChecksRubricPromptVersion(t *testing.T) {
 			TaskDigest: TaskDigest(trace, model.RubricSourceFull),
 		},
 	}
-	if Fresh(scored, trace) {
+	if FreshAgainstTrace(scored, trace) {
 		t.Fatal("scored rubric without a rubric prompt version must be stale")
 	}
 	scored.Judge.RubricPromptVersion = RubricPromptVersion
-	if !Fresh(scored, trace) {
+	if !FreshAgainstTrace(scored, trace) {
 		t.Fatal("expected fresh with matching rubric prompt version")
 	}
 	// A scored rubric that cannot say what it fingerprinted is stale.
 	scored.Rubric.Source = ""
-	if Fresh(scored, trace) {
+	if FreshAgainstTrace(scored, trace) {
 		t.Fatal("scored rubric without a source must be stale")
 	}
 	scored.Rubric.Source = model.RubricSourceFull
 	scored.Rubric.TaskDigest = "stale"
-	if Fresh(scored, trace) {
+	if FreshAgainstTrace(scored, trace) {
 		t.Fatal("scored rubric with a mismatched task digest must be stale")
 	}
 
 	// Deterministic skips and rubric-less reports never pin the version.
 	skipped := &model.Report{Version: 1, Judge: base,
 		Rubric: &model.Rubric{Status: model.RubricStatusUnavailable, Reason: model.RubricReasonWeakTaskText}}
-	if !Fresh(skipped, trace) {
+	if !FreshAgainstTrace(skipped, trace) {
 		t.Fatal("deterministic skip must stay fresh")
 	}
 	bare := &model.Report{Version: 1, Judge: base}
-	if !Fresh(bare, trace) {
+	if !FreshAgainstTrace(bare, trace) {
 		t.Fatal("rubric-less report must stay fresh")
 	}
 }
@@ -562,10 +562,10 @@ func TestFreshTracksTaskEvidenceBeyondScoringWindow(t *testing.T) {
 			TaskDigest: TaskDigest(before, model.RubricSourceFull),
 		},
 	}
-	if !Fresh(report, before) {
+	if !FreshAgainstTrace(report, before) {
 		t.Fatal("expected fresh against the trace it was generated from")
 	}
-	if Fresh(report, after) {
+	if FreshAgainstTrace(report, after) {
 		t.Fatal("mid-window task change must stale the rubric-bearing report")
 	}
 
@@ -593,10 +593,10 @@ func TestFreshTracksTaskEvidenceBeyondScoringWindow(t *testing.T) {
 		Judge:   model.ReportJudge{CLI: "stub", PromptVersion: PromptVersion, InputDigest: InputDigest(weakBefore)},
 		Rubric:  &model.Rubric{Status: model.RubricStatusUnavailable, Reason: model.RubricReasonWeakTaskText},
 	}
-	if !Fresh(skipped, weakBefore) {
+	if !FreshAgainstTrace(skipped, weakBefore) {
 		t.Fatal("weak-task-text skip should stay fresh while the evidence stays weak")
 	}
-	if Fresh(skipped, weakAfter) {
+	if FreshAgainstTrace(skipped, weakAfter) {
 		t.Fatal("enriched task evidence must stale the weak-task-text skip")
 	}
 }

--- a/internal/server/analyze.go
+++ b/internal/server/analyze.go
@@ -60,9 +60,9 @@ func (a *analyzeState) snapshot(key string) (analyzeJob, bool) {
 }
 
 // reportStateFor grades one session for the list view: "running" while a
-// judge job is in flight, then "done" / "stale" / "failed". Staleness here
-// compares the report against the summary event count — cheap, no trace
-// parse — so the badge can be a touch more approximate than the panel.
+// judge job is in flight, then "done" / "stale" / "failed". The badge uses
+// the summary approximation of freshness (no trace parse, no per-session
+// disk probe); the panel's FreshAgainstTrace check stays the precise one.
 func (s *Server) reportStateFor(meta model.SessionMeta) string {
 	job, ok := s.analyze.snapshot(meta.Key)
 	var report *model.Report
@@ -74,18 +74,12 @@ func (s *Server) reportStateFor(meta model.SessionMeta) string {
 	case ok && job.report != nil:
 		report = job.report
 	default:
-		report = s.reportCache.Load(meta.Key)
+		report = s.reportIndex.load(s.reportCache, meta.Key)
 	}
 	if report == nil {
 		return ""
 	}
-	// A report without an input digest predates digest freshness and the
-	// panel will grade it stale — say so here too rather than disagree. User
-	// turns catch message-only growth the event count is blind to.
-	if report.Session.EventCount != meta.EventCount ||
-		report.Session.UserTurns != meta.UserTurns ||
-		report.Judge.PromptVersion != judge.PromptVersion ||
-		report.Judge.InputDigest == "" {
+	if !judge.FreshAgainstSummary(report, meta) {
 		return "stale"
 	}
 	return "done"
@@ -147,12 +141,12 @@ func (s *Server) handleSessionReport(w http.ResponseWriter, r *http.Request, sel
 	case ok && job.report != nil:
 		status.State = "done"
 		status.Report = job.report
-		status.Stale = !judge.Fresh(job.report, trace)
+		status.Stale = !judge.FreshAgainstTrace(job.report, trace)
 	default:
-		if cached := s.reportCache.Load(meta.Key); cached != nil {
+		if cached := s.reportIndex.load(s.reportCache, meta.Key); cached != nil {
 			status.State = "done"
 			status.Report = cached
-			status.Stale = !judge.Fresh(cached, trace)
+			status.Stale = !judge.FreshAgainstTrace(cached, trace)
 		}
 	}
 	writeJSON(w, status)
@@ -266,6 +260,11 @@ func (s *Server) runAnalyze(key string, trace *model.Trace, job *analyzeJob, cli
 	persisted := false
 	if err == nil && !noRubric && s.reportCache.Dir != "" {
 		persisted = s.reportCache.Store(key, report) == nil
+	}
+	if persisted {
+		// Polls landing between the store and the index's next directory scan
+		// must find the report once the job entry is dropped below.
+		s.reportIndex.markPresent(key)
 	}
 
 	s.analyze.mu.Lock()

--- a/internal/server/codex_index_test.go
+++ b/internal/server/codex_index_test.go
@@ -1,0 +1,40 @@
+package server
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// A Codex thread rename only touches session_index.jsonl, never the session
+// file. The summary cache must treat the index as a summary input, or the
+// rename stays invisible for the life of the serve process.
+func TestFreshScanPicksUpCodexTitleIndexChange(t *testing.T) {
+	base := t.TempDir()
+	codexDir := filepath.Join(base, "sessions")
+	if err := os.MkdirAll(codexDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeServerJSONL(t, filepath.Join(codexDir, "s1.jsonl"), map[string]any{
+		"timestamp": "2026-07-09T00:00:00Z",
+		"type":      "session_meta",
+		"payload":   map[string]any{"id": "codex-title", "cwd": "/tmp"},
+	})
+	writeIndex := func(title string) {
+		writeServerJSONL(t, filepath.Join(base, "session_index.jsonl"),
+			map[string]any{"id": "codex-title", "thread_name": title})
+	}
+	writeIndex("Title One")
+
+	s := New(Config{ClaudeDir: filepath.Join(t.TempDir(), "claude"), CodexDir: codexDir, PiDir: filepath.Join(t.TempDir(), "pi")})
+	initial := requestSessions(t, s, "/api/sessions")
+	if len(initial) != 1 || initial[0].Title != "Title One" {
+		t.Fatalf("initial sessions = %#v", initial)
+	}
+
+	writeIndex("Title Two Updated")
+	fresh := requestSessions(t, s, "/api/sessions?fresh=1")
+	if len(fresh) != 1 || fresh[0].Title != "Title Two Updated" {
+		t.Fatalf("index change not picked up: %#v", fresh)
+	}
+}

--- a/internal/server/hardening_test.go
+++ b/internal/server/hardening_test.go
@@ -15,15 +15,19 @@ func TestHandlerRejectsNonLocalHost(t *testing.T) {
 	s := New(Config{})
 	handler := s.handler()
 
-	req := httptest.NewRequest(http.MethodGet, "/api/repomap", nil)
-	req.Host = "evil.example:8765"
-	resp := httptest.NewRecorder()
-	handler.ServeHTTP(resp, req)
-	if resp.Code != http.StatusForbidden {
-		t.Fatalf("non-local Host status = %d, want 403", resp.Code)
+	// A stray bracket must not normalize into an allowed host.
+	for _, host := range []string{"evil.example:8765", "localhost]", "localhost]:8765", "[localhost:8765"} {
+		req := httptest.NewRequest(http.MethodGet, "/api/repomap", nil)
+		req.Host = host
+		resp := httptest.NewRecorder()
+		handler.ServeHTTP(resp, req)
+		if resp.Code != http.StatusForbidden {
+			t.Fatalf("Host %q status = %d, want 403", host, resp.Code)
+		}
 	}
 
-	for _, host := range []string{"127.0.0.1:8765", "localhost:8765", "[::1]:8765"} {
+	// Host names are case-insensitive.
+	for _, host := range []string{"127.0.0.1:8765", "localhost:8765", "LOCALHOST:8765", "[::1]:8765"} {
 		req := httptest.NewRequest(http.MethodGet, "/api/repomap", nil)
 		req.Host = host
 		resp := httptest.NewRecorder()

--- a/internal/server/hardening_test.go
+++ b/internal/server/hardening_test.go
@@ -1,0 +1,137 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/cosmtrek/mindwalk/internal/model"
+)
+
+func TestHandlerRejectsNonLocalHost(t *testing.T) {
+	s := New(Config{})
+	handler := s.handler()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/repomap", nil)
+	req.Host = "evil.example:8765"
+	resp := httptest.NewRecorder()
+	handler.ServeHTTP(resp, req)
+	if resp.Code != http.StatusForbidden {
+		t.Fatalf("non-local Host status = %d, want 403", resp.Code)
+	}
+
+	for _, host := range []string{"127.0.0.1:8765", "localhost:8765", "[::1]:8765"} {
+		req := httptest.NewRequest(http.MethodGet, "/api/repomap", nil)
+		req.Host = host
+		resp := httptest.NewRecorder()
+		handler.ServeHTTP(resp, req)
+		if resp.Code == http.StatusForbidden {
+			t.Fatalf("local Host %q rejected", host)
+		}
+	}
+}
+
+func TestAnalyzeRejectsCrossSiteRequests(t *testing.T) {
+	s := New(Config{})
+	handler := s.handler()
+	post := func(origin, fetchSite string) int {
+		req := httptest.NewRequest(http.MethodPost, "/api/sessions/nope/analyze", nil)
+		req.Host = "127.0.0.1:8765"
+		if origin != "" {
+			req.Header.Set("Origin", origin)
+		}
+		if fetchSite != "" {
+			req.Header.Set("Sec-Fetch-Site", fetchSite)
+		}
+		resp := httptest.NewRecorder()
+		handler.ServeHTTP(resp, req)
+		return resp.Code
+	}
+
+	rejected := []struct{ origin, fetchSite string }{
+		{"https://evil.example", ""},
+		{"null", ""},
+		{"", "cross-site"},
+		{"", "same-site"},
+		{"http://127.0.0.1:8765", "cross-site"},
+	}
+	for _, c := range rejected {
+		if code := post(c.origin, c.fetchSite); code != http.StatusForbidden {
+			t.Fatalf("origin=%q fetchSite=%q status = %d, want 403", c.origin, c.fetchSite, code)
+		}
+	}
+
+	// Same-origin browser requests and non-browser clients (no Origin) must
+	// pass the middleware; 404 here means the handler ran and found no session.
+	allowed := []struct{ origin, fetchSite string }{
+		{"", ""},
+		{"http://127.0.0.1:8765", "same-origin"},
+		{"http://localhost:8765", ""},
+		{"", "none"},
+	}
+	for _, c := range allowed {
+		if code := post(c.origin, c.fetchSite); code == http.StatusForbidden {
+			t.Fatalf("origin=%q fetchSite=%q rejected by middleware", c.origin, c.fetchSite)
+		}
+	}
+}
+
+// Cross-site GETs stay readable-by-middleware (CORS already blocks the
+// response); only non-GET methods carry the Origin gate.
+func TestCrossSiteGetPassesMiddleware(t *testing.T) {
+	s := New(Config{})
+	req := httptest.NewRequest(http.MethodGet, "/api/sessions", nil)
+	req.Host = "127.0.0.1:8765"
+	req.Header.Set("Origin", "https://evil.example")
+	req.Header.Set("Sec-Fetch-Site", "cross-site")
+	resp := httptest.NewRecorder()
+	s.handler().ServeHTTP(resp, req)
+	if resp.Code == http.StatusForbidden {
+		t.Fatal("cross-site GET rejected; reads are CORS-protected, not middleware-gated")
+	}
+}
+
+func TestRepoMapUsesInjectedBuilder(t *testing.T) {
+	repoRoot := t.TempDir()
+	if err := os.WriteFile(filepath.Join(repoRoot, "a.go"), []byte("package demo\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	s := New(Config{})
+	calls := 0
+	s.buildCityMap = func(repo string, trace *model.Trace) (*model.CityMap, error) {
+		calls++
+		return emptyCityMap(repo), nil
+	}
+	if _, err := s.repoCityMap(repoRoot); err != nil {
+		t.Fatal(err)
+	}
+	if calls != 1 {
+		t.Fatalf("injected builder calls = %d, want 1", calls)
+	}
+}
+
+func TestAgentGraphCacheIsBounded(t *testing.T) {
+	s := New(Config{})
+	s.mu.Lock()
+	base := time.Now()
+	for i := 0; i < agentGraphMaxEntries+5; i++ {
+		s.agentGraphs[string(rune('a'+i))] = agentGraphCacheEntry{
+			graph: &model.AgentGraph{},
+			used:  base.Add(time.Duration(i) * time.Second),
+		}
+	}
+	s.evictAgentGraphsLocked()
+	n := len(s.agentGraphs)
+	_, newestKept := s.agentGraphs[string(rune('a'+agentGraphMaxEntries+4))]
+	_, oldestKept := s.agentGraphs["a"]
+	s.mu.Unlock()
+	if n != agentGraphMaxEntries {
+		t.Fatalf("agent graph cache size = %d, want %d", n, agentGraphMaxEntries)
+	}
+	if !newestKept || oldestKept {
+		t.Fatalf("eviction order wrong: newestKept=%v oldestKept=%v", newestKept, oldestKept)
+	}
+}

--- a/internal/server/hardening_test.go
+++ b/internal/server/hardening_test.go
@@ -57,6 +57,12 @@ func TestAnalyzeRejectsCrossSiteRequests(t *testing.T) {
 		{"", "cross-site"},
 		{"", "same-site"},
 		{"http://127.0.0.1:8765", "cross-site"},
+		// Loopback is not same-origin: another local server's page — a
+		// different host name, port, or scheme — must not pass.
+		{"http://localhost:9999", ""},
+		{"http://127.0.0.1:9999", ""},
+		{"http://localhost:8765", ""},
+		{"https://127.0.0.1:8765", ""},
 	}
 	for _, c := range rejected {
 		if code := post(c.origin, c.fetchSite); code != http.StatusForbidden {
@@ -68,8 +74,8 @@ func TestAnalyzeRejectsCrossSiteRequests(t *testing.T) {
 	// pass the middleware; 404 here means the handler ran and found no session.
 	allowed := []struct{ origin, fetchSite string }{
 		{"", ""},
+		{"http://127.0.0.1:8765", ""},
 		{"http://127.0.0.1:8765", "same-origin"},
-		{"http://localhost:8765", ""},
 		{"", "none"},
 	}
 	for _, c := range allowed {

--- a/internal/server/reportindex.go
+++ b/internal/server/reportindex.go
@@ -1,0 +1,91 @@
+package server
+
+import (
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/cosmtrek/mindwalk/internal/judge"
+	"github.com/cosmtrek/mindwalk/internal/model"
+)
+
+// reportIndexTTL bounds how stale the directory listing may get. The reports
+// directory is also written by the CLI, so the listing cannot be trusted for
+// long; 5s matches the session-list polling cadence.
+const reportIndexTTL = 5 * time.Second
+
+// reportIndex keeps the session list's report lookups off the disk hot path.
+// Most sessions have no report: one ReadDir per TTL answers "which sessions
+// have a report at all" instead of a stat per session per request, and
+// per-key loads are memoized against the report file's fingerprint so a
+// report is re-read only when it changed. Same-process writers must call
+// markPresent after storing a report — the TTL only covers writers this
+// server cannot see.
+type reportIndex struct {
+	mu      sync.Mutex
+	scanned time.Time
+	present map[string]bool
+	loaded  map[string]reportMemo
+}
+
+type reportMemo struct {
+	fingerprint fileFingerprint
+	report      *model.Report
+}
+
+// load returns the cached report for key, or nil when none exists. The cache
+// is passed per call so a Dir override after construction is observed.
+func (ri *reportIndex) load(cache judge.Cache, key string) *model.Report {
+	if cache.Dir == "" || key == "" {
+		return nil
+	}
+	ri.mu.Lock()
+	defer ri.mu.Unlock()
+	if time.Since(ri.scanned) >= reportIndexTTL {
+		ri.present = map[string]bool{}
+		if entries, err := os.ReadDir(cache.Dir); err == nil {
+			for _, entry := range entries {
+				if name, ok := strings.CutSuffix(entry.Name(), ".json"); ok {
+					ri.present[name] = true
+				}
+			}
+		}
+		for key := range ri.loaded {
+			if !ri.present[key] {
+				delete(ri.loaded, key)
+			}
+		}
+		ri.scanned = time.Now()
+	}
+	if !ri.present[key] {
+		return nil
+	}
+	fingerprint, err := fingerprintFile(cache.Path(key))
+	if err != nil {
+		delete(ri.loaded, key)
+		return nil
+	}
+	if memo, ok := ri.loaded[key]; ok && memo.fingerprint.equal(fingerprint) {
+		return memo.report
+	}
+	report := cache.Load(key)
+	if ri.loaded == nil {
+		ri.loaded = map[string]reportMemo{}
+	}
+	ri.loaded[key] = reportMemo{fingerprint: fingerprint, report: report}
+	return report
+}
+
+// markPresent records that a report for key now exists on disk, so a load
+// within the listing TTL finds it. Without this, a poll landing right after
+// the server persisted a report — and after the job entry was dropped —
+// would read "no report" until the next directory scan.
+func (ri *reportIndex) markPresent(key string) {
+	ri.mu.Lock()
+	defer ri.mu.Unlock()
+	if ri.present == nil {
+		ri.present = map[string]bool{}
+	}
+	ri.present[key] = true
+}

--- a/internal/server/reportindex_test.go
+++ b/internal/server/reportindex_test.go
@@ -1,0 +1,116 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"github.com/cosmtrek/mindwalk/internal/judge"
+	"github.com/cosmtrek/mindwalk/internal/model"
+)
+
+func validReport(eventCount, userTurns int, digest string) *model.Report {
+	return &model.Report{
+		Version:    1,
+		Session:    model.ReportSession{ID: "s", EventCount: eventCount, UserTurns: userTurns},
+		Judge:      model.ReportJudge{CLI: "stub", PromptVersion: judge.PromptVersion, InputDigest: digest},
+		Dimensions: []model.ReportDimension{{Name: "exploration", Findings: []model.ReportFinding{}}},
+	}
+}
+
+func TestReportIndexMemoizesAndTracksFileChanges(t *testing.T) {
+	cache := judge.Cache{Dir: t.TempDir()}
+	if err := cache.Store("key1", validReport(3, 1, "digest-one")); err != nil {
+		t.Fatal(err)
+	}
+	ri := &reportIndex{}
+	first := ri.load(cache, "key1")
+	if first == nil {
+		t.Fatal("stored report not found")
+	}
+	if second := ri.load(cache, "key1"); second != first {
+		t.Fatal("unchanged file was re-read instead of memoized")
+	}
+	if ri.load(cache, "absent") != nil {
+		t.Fatal("absent key returned a report")
+	}
+
+	if err := cache.Store("key1", validReport(3, 1, "digest-two-changed")); err != nil {
+		t.Fatal(err)
+	}
+	third := ri.load(cache, "key1")
+	if third == nil || third == first || third.Judge.InputDigest != "digest-two-changed" {
+		t.Fatalf("changed file not reloaded: %+v", third)
+	}
+}
+
+func TestReportIndexMarkPresentBeatsListingTTL(t *testing.T) {
+	cache := judge.Cache{Dir: t.TempDir()}
+	ri := &reportIndex{}
+	if ri.load(cache, "k") != nil {
+		t.Fatal("empty dir returned a report")
+	}
+	// The listing is now warm and won't rescan for reportIndexTTL: a report
+	// stored by this process must be pushed into the index, not discovered.
+	if err := cache.Store("k", validReport(1, 1, "d")); err != nil {
+		t.Fatal(err)
+	}
+	if ri.load(cache, "k") != nil {
+		t.Fatal("listing rescanned within TTL; markPresent has nothing to fix")
+	}
+	ri.markPresent("k")
+	if ri.load(cache, "k") == nil {
+		t.Fatal("markPresent did not surface the stored report")
+	}
+}
+
+func TestSessionListReportStatesComeFromIndex(t *testing.T) {
+	claudeDir := t.TempDir()
+	for _, name := range []string{"scored", "staled", "bare"} {
+		writeServerSession(t, filepath.Join(claudeDir, name+".jsonl"),
+			`{"type":"user","timestamp":"2026-07-09T00:00:00Z","sessionId":"`+name+`","cwd":"/tmp","message":{"role":"user","content":"do"}}`,
+			`{"type":"assistant","timestamp":"2026-07-09T00:00:01Z","sessionId":"`+name+`","cwd":"/tmp","message":{"role":"assistant","content":[{"type":"tool_use","id":"r1","name":"Read","input":{"file_path":"/tmp/a.go"}}]}}`,
+			`{"type":"user","timestamp":"2026-07-09T00:00:02Z","sessionId":"`+name+`","cwd":"/tmp","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"r1","content":"ok","is_error":false}]}}`,
+		)
+	}
+	reportsDir := t.TempDir()
+
+	// Seed reports before the server exists so its first listing sees them.
+	seed := New(Config{ClaudeDir: claudeDir, CodexDir: filepath.Join(t.TempDir(), "codex")})
+	seed.reportCache.Dir = reportsDir
+	scored, err := seed.findSession("scored")
+	if err != nil {
+		t.Fatal(err)
+	}
+	staled, err := seed.findSession("staled")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := seed.reportCache.Store(scored.Key, validReport(scored.EventCount, scored.UserTurns, "d")); err != nil {
+		t.Fatal(err)
+	}
+	if err := seed.reportCache.Store(staled.Key, validReport(staled.EventCount+1, staled.UserTurns, "d")); err != nil {
+		t.Fatal(err)
+	}
+
+	s := New(Config{ClaudeDir: claudeDir, CodexDir: filepath.Join(t.TempDir(), "codex")})
+	s.reportCache.Dir = reportsDir
+	resp := httptest.NewRecorder()
+	s.handleSessions(resp, httptest.NewRequest(http.MethodGet, "/api/sessions", nil))
+	if resp.Code != http.StatusOK {
+		t.Fatalf("sessions status = %d", resp.Code)
+	}
+	var items []sessionListItem
+	if err := json.Unmarshal(resp.Body.Bytes(), &items); err != nil {
+		t.Fatal(err)
+	}
+	states := map[string]string{}
+	for _, item := range items {
+		states[item.ID] = item.ReportState
+	}
+	if states["scored"] != "done" || states["staled"] != "stale" || states["bare"] != "" {
+		t.Fatalf("states = %#v", states)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -182,7 +182,9 @@ func (s *Server) handler() http.Handler {
 // point an attacker-controlled name at 127.0.0.1. The Host check pins the
 // name rebinding would forge; the Origin / Sec-Fetch-Site check stops
 // cross-site state changes — POST /analyze starts a judge run that costs
-// tokens and minutes. Requests without an Origin header (curl, same-origin
+// tokens and minutes. An Origin must name this server exactly: another
+// loopback origin (a different local server's page, or another port) is
+// still cross-origin. Requests without an Origin header (curl, same-origin
 // navigations) pass untouched.
 func requireLoopback(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -191,12 +193,9 @@ func requireLoopback(next http.Handler) http.Handler {
 			return
 		}
 		if r.Method != http.MethodGet {
-			if origin := r.Header.Get("Origin"); origin != "" {
-				parsed, err := url.Parse(origin)
-				if err != nil || !loopbackHost(parsed.Host) {
-					http.Error(w, "forbidden: cross-site request", http.StatusForbidden)
-					return
-				}
+			if origin := r.Header.Get("Origin"); origin != "" && !sameOrigin(origin, r.Host) {
+				http.Error(w, "forbidden: cross-site request", http.StatusForbidden)
+				return
 			}
 			switch r.Header.Get("Sec-Fetch-Site") {
 			case "", "same-origin", "none":
@@ -216,6 +215,28 @@ func loopbackHost(hostport string) bool {
 	}
 	host = strings.Trim(host, "[]")
 	return host == "127.0.0.1" || host == "localhost" || host == "::1"
+}
+
+// sameOrigin reports whether the Origin header names this server: scheme
+// http (the server never terminates TLS) and the same normalized host:port
+// the request was addressed to. "null" and malformed origins fail parsing
+// and are rejected.
+func sameOrigin(origin, requestHost string) bool {
+	parsed, err := url.Parse(origin)
+	if err != nil || parsed.Scheme != "http" || parsed.Host == "" {
+		return false
+	}
+	return hostPortKey(parsed.Host) == hostPortKey(requestHost)
+}
+
+// hostPortKey normalizes a host:port for origin comparison: lowercased host,
+// IPv6 brackets stripped, the http default port made explicit.
+func hostPortKey(hostport string) string {
+	host, port, err := net.SplitHostPort(hostport)
+	if err != nil {
+		host, port = hostport, "80"
+	}
+	return strings.ToLower(strings.Trim(host, "[]")) + ":" + port
 }
 
 func (s *Server) handleSessions(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -64,6 +64,7 @@ type Server struct {
 
 	analyze     analyzeState
 	reportCache judge.Cache
+	reportIndex reportIndex
 }
 
 type repoMapEntry struct {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -213,7 +213,7 @@ func loopbackHost(hostport string) bool {
 	if h, _, err := net.SplitHostPort(hostport); err == nil {
 		host = h
 	}
-	host = strings.Trim(host, "[]")
+	host = normalizeHost(host)
 	return host == "127.0.0.1" || host == "localhost" || host == "::1"
 }
 
@@ -236,7 +236,17 @@ func hostPortKey(hostport string) string {
 	if err != nil {
 		host, port = hostport, "80"
 	}
-	return strings.ToLower(strings.Trim(host, "[]")) + ":" + port
+	return normalizeHost(host) + ":" + port
+}
+
+// normalizeHost lowercases a host and strips one matched pair of IPv6
+// brackets. Unmatched brackets stay put, so a malformed host ("localhost]")
+// remains malformed instead of normalizing into an allowed value.
+func normalizeHost(host string) string {
+	if strings.HasPrefix(host, "[") && strings.HasSuffix(host, "]") {
+		host = host[1 : len(host)-1]
+	}
+	return strings.ToLower(host)
 }
 
 func (s *Server) handleSessions(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -97,6 +97,7 @@ type agentGraphFingerprint struct {
 type agentGraphCacheEntry struct {
 	fingerprint agentGraphFingerprint
 	graph       *model.AgentGraph
+	used        time.Time
 }
 
 type inflightAgentGraph struct {
@@ -122,6 +123,9 @@ const (
 	// serve current as the tree changes without rebuilding on every request
 	repoMapTTL        = 30 * time.Second
 	repoMapMaxEntries = 16
+	// agent graphs are small but were the one unbounded cache; bound them the
+	// same way as traces
+	agentGraphMaxEntries = 16
 )
 
 func New(cfg Config) *Server {
@@ -147,12 +151,6 @@ func New(cfg Config) *Server {
 }
 
 func (s *Server) Start(openBrowser bool) error {
-	mux := http.NewServeMux()
-	mux.HandleFunc("/api/sessions", s.handleSessions)
-	mux.HandleFunc("/api/sessions/", s.handleSessionResource)
-	mux.HandleFunc("/api/repomap", s.handleRepoMap)
-	mux.HandleFunc("/", s.handleStatic)
-
 	port := s.cfg.Port
 	if port == 0 {
 		port = 0
@@ -179,7 +177,58 @@ func (s *Server) Start(openBrowser bool) error {
 		_ = openURL(pageURL)
 	}
 	fmt.Printf("mindwalk serving %s\n", addr)
-	return http.Serve(ln, mux)
+	return http.Serve(ln, s.handler())
+}
+
+func (s *Server) handler() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/sessions", s.handleSessions)
+	mux.HandleFunc("/api/sessions/", s.handleSessionResource)
+	mux.HandleFunc("/api/repomap", s.handleRepoMap)
+	mux.HandleFunc("/", s.handleStatic)
+	return requireLoopback(mux)
+}
+
+// requireLoopback rejects requests that did not originate locally. Binding to
+// 127.0.0.1 alone does not keep browsers out: any web page can fire
+// cross-site requests straight at a loopback port, and DNS rebinding can
+// point an attacker-controlled name at 127.0.0.1. The Host check pins the
+// name rebinding would forge; the Origin / Sec-Fetch-Site check stops
+// cross-site state changes — POST /analyze starts a judge run that costs
+// tokens and minutes. Requests without an Origin header (curl, same-origin
+// navigations) pass untouched.
+func requireLoopback(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !loopbackHost(r.Host) {
+			http.Error(w, "forbidden: non-local Host", http.StatusForbidden)
+			return
+		}
+		if r.Method != http.MethodGet {
+			if origin := r.Header.Get("Origin"); origin != "" {
+				parsed, err := url.Parse(origin)
+				if err != nil || !loopbackHost(parsed.Host) {
+					http.Error(w, "forbidden: cross-site request", http.StatusForbidden)
+					return
+				}
+			}
+			switch r.Header.Get("Sec-Fetch-Site") {
+			case "", "same-origin", "none":
+			default:
+				http.Error(w, "forbidden: cross-site request", http.StatusForbidden)
+				return
+			}
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+func loopbackHost(hostport string) bool {
+	host := hostport
+	if h, _, err := net.SplitHostPort(hostport); err == nil {
+		host = h
+	}
+	host = strings.Trim(host, "[]")
+	return host == "127.0.0.1" || host == "localhost" || host == "::1"
 }
 
 func (s *Server) handleSessions(w http.ResponseWriter, r *http.Request) {
@@ -370,7 +419,7 @@ func (s *Server) repoCityMap(repo string) (*model.CityMap, error) {
 	if entry, ok := s.repoMaps[repo]; ok && time.Since(entry.builtAt) < repoMapTTL {
 		return entry.city, nil
 	}
-	city, err := citymap.Builder{}.Build(repo, nil)
+	city, err := s.buildCityMap(repo, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -728,6 +777,8 @@ func (s *Server) agentGraph(root model.SessionMeta) (*model.AgentGraph, error) {
 
 		s.mu.Lock()
 		if cached, ok := s.agentGraphs[root.Key]; ok && cached.fingerprint == fingerprint {
+			cached.used = time.Now()
+			s.agentGraphs[root.Key] = cached
 			s.mu.Unlock()
 			return cached.graph, nil
 		}
@@ -784,7 +835,8 @@ func (s *Server) runAgentGraphInflight(key string, load *inflightAgentGraph, sou
 		}
 		s.mu.Lock()
 		if load.err == nil {
-			s.agentGraphs[key] = agentGraphCacheEntry{fingerprint: load.fingerprint, graph: load.graph}
+			s.agentGraphs[key] = agentGraphCacheEntry{fingerprint: load.fingerprint, graph: load.graph, used: time.Now()}
+			s.evictAgentGraphsLocked()
 		}
 		if s.agentGraphLoads[key] == load {
 			delete(s.agentGraphLoads, key)
@@ -793,6 +845,25 @@ func (s *Server) runAgentGraphInflight(key string, load *inflightAgentGraph, sou
 		s.mu.Unlock()
 	}()
 	load.graph, load.err = source.BuildAgentGraph(root, catalog)
+}
+
+// evictAgentGraphsLocked bounds the graph cache by dropping the least
+// recently used entries. Caller must hold mu.
+func (s *Server) evictAgentGraphsLocked() {
+	for len(s.agentGraphs) > agentGraphMaxEntries {
+		var oldestKey string
+		var oldest time.Time
+		for key, entry := range s.agentGraphs {
+			if oldestKey == "" || entry.used.Before(oldest) {
+				oldestKey = key
+				oldest = entry.used
+			}
+		}
+		if oldestKey == "" {
+			return
+		}
+		delete(s.agentGraphs, oldestKey)
+	}
 }
 
 func (s *Server) findCatalogSession(key string) (model.SessionMeta, error) {
@@ -852,6 +923,7 @@ func (s *Server) loadTraceAndMap(meta model.SessionMeta) (*model.Trace, *model.C
 	}
 	city, err := s.buildCityMap(repoRoot, trace)
 	if err != nil {
+		log.Printf("mindwalk: citymap build failed for %s: %v; serving empty map", repoRoot, err)
 		city = emptyCityMap(repoRoot)
 	} else {
 		assignFileIDs(trace, city)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -54,12 +54,7 @@ type Server struct {
 	sessionCatalog  map[string]model.SessionMeta
 	sessionAt       time.Time
 	freshGen        uint64
-	traces          map[string]*model.Trace
-	maps            map[string]*model.CityMap
-	cacheAt         map[string]time.Time
-	cacheUsed       map[string]time.Time
-	cacheFile       map[string]fileFingerprint
-	inflight        map[string]*inflightLoad
+	traceStore      *traceStore
 	agentGraphs     map[string]agentGraphCacheEntry
 	agentGraphLoads map[string]*inflightAgentGraph
 	summaries       map[string]summaryCacheEntry
@@ -74,14 +69,6 @@ type Server struct {
 type repoMapEntry struct {
 	city    *model.CityMap
 	builtAt time.Time
-}
-
-type inflightLoad struct {
-	done        chan struct{}
-	fingerprint fileFingerprint
-	trace       *model.Trace
-	city        *model.CityMap
-	err         error
 }
 
 type fileFingerprint struct {
@@ -129,15 +116,9 @@ const (
 )
 
 func New(cfg Config) *Server {
-	return &Server{
+	s := &Server{
 		cfg:             cfg,
 		adapters:        []adapter.Source{claudecode.Adapter{Dir: cfg.ClaudeDir}, codex.Adapter{Dir: cfg.CodexDir}, pi.Adapter{Dir: cfg.PiDir}},
-		traces:          map[string]*model.Trace{},
-		maps:            map[string]*model.CityMap{},
-		cacheAt:         map[string]time.Time{},
-		cacheUsed:       map[string]time.Time{},
-		cacheFile:       map[string]fileFingerprint{},
-		inflight:        map[string]*inflightLoad{},
 		agentGraphs:     map[string]agentGraphCacheEntry{},
 		agentGraphLoads: map[string]*inflightAgentGraph{},
 		summaries:       map[string]summaryCacheEntry{},
@@ -148,6 +129,10 @@ func New(cfg Config) *Server {
 		analyze:     analyzeState{jobs: map[string]*analyzeJob{}},
 		reportCache: judge.Cache{Dir: judge.DefaultCacheDir()},
 	}
+	// Method values, not results: the store observes buildCityMap overrides
+	// made after construction (tests swap it per case).
+	s.traceStore = newTraceStore(s.loadTraceAndMap, s.parseSessionTrace)
+	return s
 }
 
 func (s *Server) Start(openBrowser bool) error {
@@ -372,7 +357,9 @@ func (s *Server) handleSessionAgentTrace(w http.ResponseWriter, r *http.Request,
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	trace, err := s.parseSessionTrace(child)
+	// The raw layer caches the unprojected parse; projecting onto the root
+	// city clones, so the cached trace is never mutated.
+	trace, err := s.traceStore.LoadRaw(child)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -681,55 +668,7 @@ func (s *Server) traceAndMap(selector string) (*model.Trace, *model.CityMap, err
 }
 
 func (s *Server) traceAndMapMeta(meta model.SessionMeta) (*model.Trace, *model.CityMap, error) {
-	key := meta.Key
-	if key == "" {
-		key = adapter.SessionKey(meta.Harness, meta.Path)
-	}
-	for {
-		fingerprint, err := fingerprintFile(meta.Path)
-		if err != nil {
-			s.mu.Lock()
-			s.deleteTraceCacheLocked(key)
-			s.mu.Unlock()
-			return nil, nil, err
-		}
-
-		s.mu.Lock()
-		if trace := s.traces[key]; trace != nil {
-			cachedFingerprint, versioned := s.cacheFile[key]
-			if versioned && cachedFingerprint.equal(fingerprint) && time.Since(s.cacheAt[key]) < traceCacheTTL {
-				city := s.maps[key]
-				s.cacheUsed[key] = time.Now()
-				s.mu.Unlock()
-				return trace, city, nil
-			}
-			s.deleteTraceCacheLocked(key)
-		}
-		if load := s.inflight[key]; load != nil {
-			done := load.done
-			shareSnapshot := fingerprint.equal(load.fingerprint)
-			s.mu.Unlock()
-			<-done
-
-			// Requests that observed the same source version must receive the
-			// same trace/city snapshot, even if the active file grows while the
-			// shared parse is running. A request that already observed a newer
-			// version retries after the older load completes.
-			if shareSnapshot {
-				return load.trace, load.city, load.err
-			}
-			continue
-		}
-		load := &inflightLoad{done: make(chan struct{}), fingerprint: fingerprint}
-		s.inflight[key] = load
-		s.mu.Unlock()
-
-		// Keep the pre-parse fingerprint. If the active session grows during
-		// parsing, the next request will see a mismatch and reload it instead
-		// of treating the partial snapshot as current.
-		s.runInflight(key, load, meta, fingerprint)
-		return load.trace, load.city, load.err
-	}
+	return s.traceStore.LoadSnapshot(meta)
 }
 
 func (s *Server) agentGraph(root model.SessionMeta) (*model.AgentGraph, error) {
@@ -876,36 +815,6 @@ func (s *Server) findCatalogSession(key string) (model.SessionMeta, error) {
 	return meta, nil
 }
 
-// runInflight executes the shared load for key and publishes the result on
-// load. The finalize step — cache the result, drop the inflight entry, close
-// load.done — runs in a defer so a panicking loader cannot skip it. Without
-// that, net/http's per-connection recover would swallow the panic while the
-// inflight entry stayed registered, and every later request for the key
-// would block forever on a done channel nothing closes.
-func (s *Server) runInflight(key string, load *inflightLoad, meta model.SessionMeta, fingerprint fileFingerprint) {
-	defer func() {
-		if r := recover(); r != nil {
-			load.trace, load.city = nil, nil
-			load.err = fmt.Errorf("load session %s: %v", key, r)
-			log.Printf("mindwalk: panic loading session %s: %v\n%s", key, r, debug.Stack())
-		}
-		s.mu.Lock()
-		if load.err == nil {
-			s.traces[key] = load.trace
-			s.maps[key] = load.city
-			s.cacheFile[key] = fingerprint
-			now := time.Now()
-			s.cacheAt[key] = now
-			s.cacheUsed[key] = now
-			s.evictTraceCacheLocked()
-		}
-		delete(s.inflight, key)
-		close(load.done)
-		s.mu.Unlock()
-	}()
-	load.trace, load.city, load.err = s.loadTraceAndMap(meta)
-}
-
 func (s *Server) loadTraceAndMap(meta model.SessionMeta) (*model.Trace, *model.CityMap, error) {
 	trace, err := s.parseSessionTrace(meta)
 	if err != nil {
@@ -1006,14 +915,6 @@ func (s *Server) findSession(selector string) (model.SessionMeta, error) {
 	return model.SessionMeta{}, errors.New("session not found")
 }
 
-func (s *Server) deleteTraceCacheLocked(key string) {
-	delete(s.traces, key)
-	delete(s.maps, key)
-	delete(s.cacheAt, key)
-	delete(s.cacheUsed, key)
-	delete(s.cacheFile, key)
-}
-
 func fingerprintFile(path string) (fileFingerprint, error) {
 	info, err := os.Stat(path)
 	if err != nil {
@@ -1024,24 +925,6 @@ func fingerprintFile(path string) (fileFingerprint, error) {
 
 func (f fileFingerprint) equal(other fileFingerprint) bool {
 	return f.size == other.size && f.modTime.Equal(other.modTime)
-}
-
-func (s *Server) evictTraceCacheLocked() {
-	for len(s.traces) > traceCacheMaxEntries {
-		var oldestKey string
-		var oldest time.Time
-		for key := range s.traces {
-			used := s.cacheUsed[key]
-			if oldestKey == "" || used.Before(oldest) {
-				oldestKey = key
-				oldest = used
-			}
-		}
-		if oldestKey == "" {
-			return
-		}
-		s.deleteTraceCacheLocked(oldestKey)
-	}
 }
 
 func (s *Server) openSessionKey() string {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -95,11 +95,12 @@ type inflightAgentGraph struct {
 }
 
 type summaryCacheEntry struct {
-	size          int64
-	modTime       time.Time
-	sidecar       fileFingerprint
-	sidecarExists bool
-	meta          model.SessionMeta
+	size    int64
+	modTime time.Time
+	// sidecar is opaque validation material for the companion files the
+	// source declared via SummaryInputs; empty when there are none.
+	sidecar string
+	meta    model.SessionMeta
 }
 
 const (
@@ -612,10 +613,10 @@ func (s *Server) summarizeCached(source adapter.Source, path string, info fs.Fil
 		}
 	}
 	key := summaryKey(source, path)
-	sidecar, sidecarExists := summarySidecarFingerprint(source, path)
+	sidecar := summarySidecarDigest(source, path)
 	s.mu.Lock()
 	if cached, ok := s.summaries[key]; ok && cached.size == info.Size() && cached.modTime.Equal(info.ModTime()) &&
-		cached.sidecarExists == sidecarExists && cached.sidecar.equal(sidecar) {
+		cached.sidecar == sidecar {
 		meta := cached.meta
 		s.mu.Unlock()
 		return meta, nil
@@ -631,22 +632,36 @@ func (s *Server) summarizeCached(source adapter.Source, path string, info fs.Fil
 	}
 	s.mu.Lock()
 	s.summaries[key] = summaryCacheEntry{
-		size:          info.Size(),
-		modTime:       info.ModTime(),
-		sidecar:       sidecar,
-		sidecarExists: sidecarExists,
-		meta:          meta,
+		size:    info.Size(),
+		modTime: info.ModTime(),
+		sidecar: sidecar,
+		meta:    meta,
 	}
 	s.mu.Unlock()
 	return meta, nil
 }
 
-func summarySidecarFingerprint(source adapter.Source, path string) (fileFingerprint, bool) {
-	if source.Harness() != "claude-code" || !strings.HasPrefix(filepath.Base(path), "agent-") {
-		return fileFingerprint{}, false
+// summarySidecarDigest fingerprints the companion files the source declares
+// for path. The server holds no harness-specific sidecar knowledge — sources
+// that keep files beside their session logs implement SummarySidecarSource.
+func summarySidecarDigest(source adapter.Source, path string) string {
+	sidecars, ok := source.(adapter.SummarySidecarSource)
+	if !ok {
+		return ""
 	}
-	fingerprint, err := fingerprintFile(strings.TrimSuffix(path, ".jsonl") + ".meta.json")
-	return fingerprint, err == nil
+	inputs := sidecars.SummaryInputs(path)
+	if len(inputs) == 0 {
+		return ""
+	}
+	var material strings.Builder
+	for _, input := range inputs {
+		if fingerprint, err := fingerprintFile(input); err == nil {
+			fmt.Fprintf(&material, "%s\x00%d\x00%d\n", input, fingerprint.size, fingerprint.modTime.UnixNano())
+		} else {
+			fmt.Fprintf(&material, "%s\x00missing\n", input)
+		}
+	}
+	return material.String()
 }
 
 func (s *Server) pruneSummaryCache(seen map[string]bool) {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -131,8 +131,11 @@ func TestDuplicateSessionIDsUseDistinctKeysAndCaches(t *testing.T) {
 			t.Fatalf("key %q loaded %q, want %q", session.Key, trace.Session.Path, session.Path)
 		}
 	}
-	if len(s.traces) != 2 {
-		t.Fatalf("trace cache entries = %d, want 2", len(s.traces))
+	s.traceStore.mu.Lock()
+	cached := len(s.traceStore.snapshots)
+	s.traceStore.mu.Unlock()
+	if cached != 2 {
+		t.Fatalf("trace cache entries = %d, want 2", cached)
 	}
 	if _, err := s.findSession("shared-id"); err == nil || !strings.Contains(err.Error(), "ambiguous") {
 		t.Fatalf("duplicate legacy ID error = %v", err)
@@ -328,9 +331,9 @@ func TestInflightLoadSurvivesPanickingLoader(t *testing.T) {
 		t.Fatalf("request after recovered panic: trace=%v city=%v err=%v", trace, city, err)
 	}
 
-	s.mu.Lock()
-	leaked := len(s.inflight)
-	s.mu.Unlock()
+	s.traceStore.mu.Lock()
+	leaked := len(s.traceStore.inflight)
+	s.traceStore.mu.Unlock()
 	if leaked != 0 {
 		t.Fatalf("inflight entries leaked: %d", leaked)
 	}
@@ -690,10 +693,12 @@ func TestAgentAPIsAreRootScoped(t *testing.T) {
 		t.Fatalf("projected child shares target line storage with source: got=%d want=4", got)
 	}
 
+	// The raw layer caches the child parse: re-requesting the same file
+	// version must serve from cache instead of re-reading the JSONL.
 	parsesBeforeSecondChild := source.parses["child-a"]
 	secondChild := requestSessionResource(t, s, http.MethodGet, "/api/sessions/root-a/agents/child-a/trace")
-	if secondChild.Code != http.StatusOK || source.parses["child-a"] != parsesBeforeSecondChild+1 {
-		t.Fatalf("direct child parse status=%d parses=%d body=%q", secondChild.Code, source.parses["child-a"], secondChild.Body.String())
+	if secondChild.Code != http.StatusOK || source.parses["child-a"] != parsesBeforeSecondChild {
+		t.Fatalf("child re-request reparsed: status=%d parses=%d body=%q", secondChild.Code, source.parses["child-a"], secondChild.Body.String())
 	}
 
 	for _, tc := range []struct {

--- a/internal/server/tracestore.go
+++ b/internal/server/tracestore.go
@@ -1,0 +1,173 @@
+package server
+
+import (
+	"fmt"
+	"log"
+	"runtime/debug"
+	"sync"
+	"time"
+
+	"github.com/cosmtrek/mindwalk/internal/adapter"
+	"github.com/cosmtrek/mindwalk/internal/model"
+)
+
+// traceStore owns every parsed-session cache behind one lock. It keeps two
+// layers with the same key space (session key) but different value semantics:
+//
+//   - snapshots: the trace projected onto its own citymap (file IDs assigned,
+//     stats recomputed against the repo file count) plus that citymap — what
+//     the session views serve.
+//   - raws: the trace exactly as the adapter parsed it, no projection — what
+//     subagent views load before projecting onto the *root* session's city.
+//
+// Keeping the layers apart means a projected snapshot can never be
+// re-projected and a raw trace can never be served where file IDs are
+// expected. Keys are session keys; the source-file fingerprint is a
+// validation field on the entry — never part of the key — so one session
+// occupies at most one slot per layer.
+type traceStore struct {
+	mu        sync.Mutex
+	snapshots map[string]*traceEntry
+	raws      map[string]*traceEntry
+	inflight  map[string]*inflightLoad
+
+	// Injected by the server: parse-and-project for snapshots, parse-only for
+	// raws. Called without the store lock held.
+	loadSnapshot func(model.SessionMeta) (*model.Trace, *model.CityMap, error)
+	loadRaw      func(model.SessionMeta) (*model.Trace, error)
+}
+
+type traceEntry struct {
+	trace       *model.Trace
+	city        *model.CityMap // nil in the raw layer
+	fingerprint fileFingerprint
+	at          time.Time
+	used        time.Time
+}
+
+type inflightLoad struct {
+	done        chan struct{}
+	fingerprint fileFingerprint
+	trace       *model.Trace
+	city        *model.CityMap
+	err         error
+}
+
+func newTraceStore(loadSnapshot func(model.SessionMeta) (*model.Trace, *model.CityMap, error), loadRaw func(model.SessionMeta) (*model.Trace, error)) *traceStore {
+	return &traceStore{
+		snapshots:    map[string]*traceEntry{},
+		raws:         map[string]*traceEntry{},
+		inflight:     map[string]*inflightLoad{},
+		loadSnapshot: loadSnapshot,
+		loadRaw:      loadRaw,
+	}
+}
+
+func (ts *traceStore) LoadSnapshot(meta model.SessionMeta) (*model.Trace, *model.CityMap, error) {
+	return ts.load(ts.snapshots, "snapshot", meta, ts.loadSnapshot)
+}
+
+func (ts *traceStore) LoadRaw(meta model.SessionMeta) (*model.Trace, error) {
+	trace, _, err := ts.load(ts.raws, "raw", meta, func(meta model.SessionMeta) (*model.Trace, *model.CityMap, error) {
+		trace, err := ts.loadRaw(meta)
+		return trace, nil, err
+	})
+	return trace, err
+}
+
+func (ts *traceStore) load(layer map[string]*traceEntry, kind string, meta model.SessionMeta, loader func(model.SessionMeta) (*model.Trace, *model.CityMap, error)) (*model.Trace, *model.CityMap, error) {
+	key := meta.Key
+	if key == "" {
+		key = adapter.SessionKey(meta.Harness, meta.Path)
+	}
+	inflightKey := kind + "\x00" + key
+	for {
+		fingerprint, err := fingerprintFile(meta.Path)
+		if err != nil {
+			ts.mu.Lock()
+			delete(layer, key)
+			ts.mu.Unlock()
+			return nil, nil, err
+		}
+
+		ts.mu.Lock()
+		if entry := layer[key]; entry != nil {
+			if entry.fingerprint.equal(fingerprint) && time.Since(entry.at) < traceCacheTTL {
+				entry.used = time.Now()
+				trace, city := entry.trace, entry.city
+				ts.mu.Unlock()
+				return trace, city, nil
+			}
+			delete(layer, key)
+		}
+		if load := ts.inflight[inflightKey]; load != nil {
+			done := load.done
+			shareSnapshot := fingerprint.equal(load.fingerprint)
+			ts.mu.Unlock()
+			<-done
+
+			// Requests that observed the same source version must receive the
+			// same trace/city snapshot, even if the active file grows while the
+			// shared parse is running. A request that already observed a newer
+			// version retries after the older load completes.
+			if shareSnapshot {
+				return load.trace, load.city, load.err
+			}
+			continue
+		}
+		load := &inflightLoad{done: make(chan struct{}), fingerprint: fingerprint}
+		ts.inflight[inflightKey] = load
+		ts.mu.Unlock()
+
+		// Keep the pre-parse fingerprint. If the active session grows during
+		// parsing, the next request will see a mismatch and reload it instead
+		// of treating the partial snapshot as current.
+		ts.run(layer, inflightKey, key, load, meta, loader)
+		return load.trace, load.city, load.err
+	}
+}
+
+// run executes the shared load for key and publishes the result on load. The
+// finalize step — cache the result, drop the inflight entry, close load.done
+// — runs in a defer so a panicking loader cannot skip it. Without that,
+// net/http's per-connection recover would swallow the panic while the
+// inflight entry stayed registered, and every later request for the key
+// would block forever on a done channel nothing closes.
+func (ts *traceStore) run(layer map[string]*traceEntry, inflightKey, key string, load *inflightLoad, meta model.SessionMeta, loader func(model.SessionMeta) (*model.Trace, *model.CityMap, error)) {
+	defer func() {
+		if r := recover(); r != nil {
+			load.trace, load.city = nil, nil
+			load.err = fmt.Errorf("load session %s: %v", key, r)
+			log.Printf("mindwalk: panic loading session %s: %v\n%s", key, r, debug.Stack())
+		}
+		ts.mu.Lock()
+		if load.err == nil {
+			now := time.Now()
+			layer[key] = &traceEntry{trace: load.trace, city: load.city, fingerprint: load.fingerprint, at: now, used: now}
+			ts.evictLocked(layer)
+		}
+		delete(ts.inflight, inflightKey)
+		close(load.done)
+		ts.mu.Unlock()
+	}()
+	load.trace, load.city, load.err = loader(meta)
+}
+
+// evictLocked bounds one layer by dropping the least recently used entries
+// once it grows past traceCacheMaxEntries. Caller must hold mu.
+func (ts *traceStore) evictLocked(layer map[string]*traceEntry) {
+	for len(layer) > traceCacheMaxEntries {
+		var oldestKey string
+		var oldest time.Time
+		for key, entry := range layer {
+			if oldestKey == "" || entry.used.Before(oldest) {
+				oldestKey = key
+				oldest = entry.used
+			}
+		}
+		if oldestKey == "" {
+			return
+		}
+		delete(layer, oldestKey)
+	}
+}

--- a/internal/server/tracestore_test.go
+++ b/internal/server/tracestore_test.go
@@ -1,0 +1,51 @@
+package server
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cosmtrek/mindwalk/internal/model"
+)
+
+// The raw and snapshot layers share a key space but must never share entries:
+// a session loaded through both APIs is parsed once per layer and each layer
+// serves its own cached value afterwards.
+func TestTraceStoreLayersAreIndependent(t *testing.T) {
+	session := filepath.Join(t.TempDir(), "s.jsonl")
+	if err := os.WriteFile(session, []byte("{}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	meta := model.SessionMeta{Key: "s", Harness: "test", Path: session}
+
+	snapshotLoads, rawLoads := 0, 0
+	snapshotTrace := &model.Trace{Session: model.TraceSession{ID: "projected"}}
+	rawTrace := &model.Trace{Session: model.TraceSession{ID: "raw"}}
+	city := &model.CityMap{}
+	ts := newTraceStore(
+		func(model.SessionMeta) (*model.Trace, *model.CityMap, error) {
+			snapshotLoads++
+			return snapshotTrace, city, nil
+		},
+		func(model.SessionMeta) (*model.Trace, error) {
+			rawLoads++
+			return rawTrace, nil
+		},
+	)
+
+	for i := 0; i < 2; i++ {
+		trace, gotCity, err := ts.LoadSnapshot(meta)
+		if err != nil || trace != snapshotTrace || gotCity != city {
+			t.Fatalf("snapshot load %d: trace=%v city=%v err=%v", i, trace, gotCity, err)
+		}
+	}
+	for i := 0; i < 2; i++ {
+		trace, err := ts.LoadRaw(meta)
+		if err != nil || trace != rawTrace {
+			t.Fatalf("raw load %d: trace=%v err=%v", i, trace, err)
+		}
+	}
+	if snapshotLoads != 1 || rawLoads != 1 {
+		t.Fatalf("loads = snapshot:%d raw:%d, want 1 each", snapshotLoads, rawLoads)
+	}
+}


### PR DESCRIPTION
Implements the four-step plan from the server architecture review (clear component boundaries, extensibility, low coupling, no performance regression). Five commits, one per step plus review fixes; each step is independently revertable. No API or schema changes.

## Step 0 — loopback hardening + one-line fixes (5a2860d, hardened in c1bb433)
- Host allowlist on every request (pins the name DNS rebinding would forge).
- Non-GET requests reject cross-site `Origin` / `Sec-Fetch-Site` so a malicious page cannot fire `POST /analyze` (a judge run costs tokens and minutes). Strict same-origin: scheme + normalized host:port must match the request exactly — another loopback origin (different host name or port) does not pass. Requests without Origin (curl) pass untouched.
- Log citymap build failures instead of silently serving an empty map.
- `repoCityMap` goes through the injected `buildCityMap` (repo-map path is now stubbable in tests).
- Bound the agent-graph cache (previously the one unbounded cache), LRU 16.

## Step 1 — two-layer traceStore (434ed8a)
Five parallel maps + inflight registry kept consistent by convention collapse into one self-locked `traceStore` with two layers sharing a key space:
- **snapshots**: trace projected onto its own citymap + that citymap
- **raws**: the unprojected parse, for subagent views that project onto the *root* session's city

Separate layers prevent a projected snapshot from being re-projected and a raw trace from being served where file IDs are expected. Fingerprints stay validation fields, never key components. Inflight semantics moved unchanged (same-fingerprint sharing, newer-observer retry, panic-surviving finalize). Child agent traces no longer re-parse their JSONL on every request — they hit the raw layer (same TTL/LRU numbers).

## Step 2 — sidecar knowledge behind the adapter boundary (02d0982, extended in c1bb433)
`summarySidecarFingerprint` hardcoded claude-code's `agent-*.meta.json` in the server. A narrow `SummarySidecarSource` interface (same type-assertion shape as `AgentGraphSource`) lets a source declare the companion files its `Summarize` reads; the server only fingerprints what comes back. Review follow-up: codex also reads `session_index.jsonl` for thread titles — it now declares its index candidates without stat-gating, so a rename (or an index created after startup) invalidates cached summaries. pi reads no sidecars.

## Step 3 — report-state index + two named freshness checks (f56a760)
The session list probed the reports directory once per session per request (~1100 sessions, 17 reports locally). A `reportIndex` now ReadDirs once per 5s TTL and memoizes loaded reports against the report file's fingerprint; same-process stores call `markPresent` to cover the store→next-scan window. `judge.Fresh` splits into `FreshAgainstTrace` (panel, precise) and `FreshAgainstSummary` (list badge, no trace parse) so both tiers of the deliberate approximate/precise layering live in one place.

## Verification
- `gofmt` clean, `go vet ./...`, `go test ./...` all green (14 new tests)
- `go test -race -count=1 ./internal/server ./internal/adapter/...` green
- `make test` incl. web build passes
- Live-process smoke: normal GET 200; forged Host 403; cross-site `Origin` POST 403 (including `localhost:9999` → `127.0.0.1` cross-port); no-Origin POST reaches handlers
- Guardrails held: cache TTL/LRU numbers and semantics unchanged, inflight sharing preserved, judge sealing and analyze 409/429 untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)