### PR TITLE
feat(model): observability signals, provider-executed flag, agent metadata [1/3]

### DIFF
--- a/internal/adapter/claudecode/adapter.go
+++ b/internal/adapter/claudecode/adapter.go
@@ -261,7 +261,7 @@ func (a Adapter) Parse(path string) (*model.Trace, error) {
 	}
 	trace.Session.EventCount = len(trace.Events)
 	// Claude Code tool results carry an is_error flag set by the harness.
-	trace.Stats = model.ComputeStats(trace, 0, model.ObservabilityExact)
+	trace.Stats = model.ComputeStats(trace, 0, model.ObservabilitySignals{Errors: model.ObservabilityExact})
 	if !recognized {
 		return nil, fmt.Errorf("not a Claude Code session: %s", path)
 	}

--- a/internal/adapter/codex/adapter.go
+++ b/internal/adapter/codex/adapter.go
@@ -365,7 +365,7 @@ func (a Adapter) Parse(path string) (*model.Trace, error) {
 	// Codex logs carry no structural error flag; failures are inferred from
 	// output text, and inner commands of the js exec runner surface only what
 	// the script chooses to print.
-	trace.Stats = model.ComputeStats(trace, 0, model.ObservabilityEstimated)
+	trace.Stats = model.ComputeStats(trace, 0, model.ObservabilitySignals{Errors: model.ObservabilityEstimated})
 	if !recognized {
 		return nil, fmt.Errorf("not a Codex session: %s", path)
 	}

--- a/internal/adapter/pi/adapter.go
+++ b/internal/adapter/pi/adapter.go
@@ -263,7 +263,7 @@ func (a Adapter) Parse(path string) (*model.Trace, error) {
 	trace.Session.Title = sessionTitle(entries, firstUserText, path)
 	trace.Session.EventCount = len(trace.Events)
 	// pi tool results carry an isError flag set by the harness.
-	trace.Stats = model.ComputeStats(trace, 0, model.ObservabilityExact)
+	trace.Stats = model.ComputeStats(trace, 0, model.ObservabilitySignals{Errors: model.ObservabilityExact})
 	return trace, err
 }
 

--- a/internal/model/agent.go
+++ b/internal/model/agent.go
@@ -24,6 +24,7 @@ const (
 	AgentLinkMethodCodexParentThreadID      = "codex-parent-thread-id"
 	AgentLinkMethodClaudeToolUseID          = "claude-tool-use-id"
 	AgentLinkMethodClaudeSubagentsDirectory = "claude-subagents-directory"
+	AgentLinkMethodCrushAgentID             = "crush-agent-id"
 	AgentLinkMethodUnavailable              = "unavailable"
 )
 

--- a/internal/model/agent_schema_test.go
+++ b/internal/model/agent_schema_test.go
@@ -70,16 +70,19 @@ func TestAgentGraphSchemaAcceptsRepresentativeGraph(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	var value any
 	if err := json.Unmarshal(document, &value); err != nil {
 		t.Fatal(err)
 	}
 
 	compiler := jsonschema.NewCompiler()
+
 	schema, err := compiler.Compile("../../schema/agent-graph.schema.json")
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	if err := schema.Validate(value); err != nil {
 		t.Fatalf("representative AgentGraph violates schema: %v\n%s", err, document)
 	}

--- a/internal/model/agent_test.go
+++ b/internal/model/agent_test.go
@@ -23,13 +23,16 @@ func TestAgentNodeOmitsMainRelationshipFields(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	var got map[string]any
 	if err := json.Unmarshal(data, &got); err != nil {
 		t.Fatal(err)
 	}
+
 	if _, ok := got["parentId"]; ok {
 		t.Fatalf("main node serialized parentId: %s", data)
 	}
+
 	if _, ok := got["launchSeq"]; ok {
 		t.Fatalf("main node serialized launchSeq: %s", data)
 	}
@@ -54,10 +57,12 @@ func TestAgentNodeSerializesZeroLaunchSeq(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	var got map[string]any
 	if err := json.Unmarshal(data, &got); err != nil {
 		t.Fatal(err)
 	}
+
 	if got["launchSeq"] != float64(0) {
 		t.Fatalf("launchSeq = %#v, JSON = %s", got["launchSeq"], data)
 	}

--- a/internal/model/fuzz_test.go
+++ b/internal/model/fuzz_test.go
@@ -1,0 +1,80 @@
+//nolint:testpackage,goconst // Match the rest of the model test files (agent_schema_test, schema_test, etc).
+package model
+
+import "testing"
+
+// FuzzComputeStats exercises ComputeStats with arbitrary trace
+// shapes and observability signals. The invariant: the function must
+// never panic and must always populate the observability grade —
+// it can be Exact, Estimated, or Unavailable, but never empty or
+// unrecognised.
+func FuzzComputeStats(f *testing.F) {
+	f.Add(uint8(0), uint8(1), "exact", "exact")
+	f.Add(uint8(1), uint8(0), "", "estimated")
+	f.Add(uint8(2), uint8(2), "garbage", "")
+	f.Add(uint8(3), uint8(0), "exact", "")
+	f.Add(uint8(0), uint8(5), "", "")
+	f.Fuzz(func(t *testing.T, actionFlag, errorFlag uint8, errorSig, readsSig string) {
+		actions := []string{"search", "read", "edit", "exec", "verify"}
+		action := actions[int(actionFlag)%len(actions)]
+
+		trace := &Trace{
+			Events: []Event{
+				{
+					Seq:          0,
+					Action:       action,
+					IsError:      errorFlag%2 == 1,
+					OutcomeKnown: errorFlag/2%2 == 1,
+					Targets: []Target{
+						{Path: "a.go", Touch: "read", Weak: errorFlag%3 == 0},
+					},
+					ResultBytes: int(errorFlag),
+				},
+			},
+		}
+
+		stats := ComputeStats(trace, int(actionFlag), ObservabilitySignals{
+			Errors: errorSig,
+			Reads:  readsSig,
+		})
+
+		// Grade must always be one of the three known values.
+		switch stats.Observability.Errors {
+		case ObservabilityExact, ObservabilityEstimated, ObservabilityUnavailable:
+		default:
+			t.Fatalf("unexpected errors grade %q", stats.Observability.Errors)
+		}
+
+		switch stats.Observability.Reads {
+		case ObservabilityExact, ObservabilityEstimated, ObservabilityUnavailable:
+		default:
+			t.Fatalf("unexpected reads grade %q", stats.Observability.Reads)
+		}
+	})
+}
+
+// TestComputeStatsNilEvents pins the panic-free behaviour for a nil
+// Events slice. Item 36 in the post-merge plan calls this out
+// explicitly — without it, a downstream caller that builds a Trace{}
+// by hand (e.g. during replay) can crash the server.
+func TestComputeStatsNilEvents(t *testing.T) {
+	t.Parallel()
+
+	stats := ComputeStats(&Trace{}, 0, ObservabilitySignals{Errors: ObservabilityExact})
+
+	if stats.Actions != (ActionCounts{}) {
+		t.Fatalf("actions = %#v, want zero", stats.Actions)
+	}
+
+	if stats.ErrorRate != 0 {
+		t.Fatalf("errorRate = %v, want 0", stats.ErrorRate)
+	}
+
+	if stats.EventsBeforeFirstEdit != 0 {
+		t.Fatalf("eventsBeforeFirstEdit = %d, want 0 (no events)", stats.EventsBeforeFirstEdit)
+	}
+
+	if stats.Observability.Reads != ObservabilityUnavailable {
+		t.Fatalf("reads = %q, want unavailable (no reads)", stats.Observability.Reads)
+	}
+}

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -61,6 +61,7 @@ type TraceSession struct {
 	ID         string `json:"id"`
 	Harness    string `json:"harness"`
 	Model      string `json:"model,omitempty"`
+	Provider   string `json:"provider,omitempty"`
 	Title      string `json:"title,omitempty"`
 	Cwd        string `json:"cwd,omitempty"`
 	Commit     string `json:"commit,omitempty"`
@@ -83,6 +84,10 @@ type Event struct {
 	// result. IsError remains sufficient to identify failures in older traces.
 	OutcomeKnown bool   `json:"outcomeKnown,omitempty"`
 	Summary      string `json:"summary"`
+	// ProviderExecuted is true when the tool was executed server-side
+	// by the model provider rather than locally by the harness. Only
+	// the crush adapter sets this today.
+	ProviderExecuted bool `json:"providerExecuted,omitempty"`
 }
 
 type Target struct {
@@ -99,9 +104,10 @@ type OutsideTouch struct {
 }
 
 type Mark struct {
-	Seq  int    `json:"seq"`
-	Type string `json:"type"`
-	Note string `json:"note,omitempty"`
+	Seq      int    `json:"seq"`
+	Type     string `json:"type"`
+	Note     string `json:"note,omitempty"`
+	Duration int    `json:"duration,omitempty"`
 }
 
 type Stats struct {
@@ -155,16 +161,29 @@ type ActionCounts struct {
 }
 
 type SessionMeta struct {
-	Key       string `json:"key"`
-	ID        string `json:"id"`
-	Harness   string `json:"harness"`
-	Title     string `json:"title,omitempty"`
+	Key     string `json:"key"`
+	ID      string `json:"id"`
+	Harness string `json:"harness"`
+	Title   string `json:"title,omitempty"`
+	// Path is the deep-link handle the server uses to recover the
+	// session. For filesystem-backed harnesses (Claude Code,
+	// Codex) it is the on-disk JSONL file path. For database-
+	// backed harnesses (Crush, future Aider/Goose) it is a
+	// synthetic URI like "crush://session/<id>" that the adapter
+	// resolves to a row in its storage. Callers that need to
+	// os.Stat the path must check for the synthetic scheme first.
 	Path      string `json:"path"`
 	Cwd       string `json:"cwd,omitempty"`
 	Model     string `json:"model,omitempty"`
+	Provider  string `json:"provider,omitempty"`
 	GitBranch string `json:"gitBranch,omitempty"`
 	StartedAt string `json:"startedAt,omitempty"`
 	EndedAt   string `json:"endedAt,omitempty"`
+	// PromptTokens and CompletionTokens are the session-level token
+	// economics from the harness's session table, when available.
+	PromptTokens     int64   `json:"promptTokens,omitempty"`
+	CompletionTokens int64   `json:"completionTokens,omitempty"`
+	Cost             float64 `json:"cost,omitempty"`
 	// EventCount and UserTurns together are the cheap staleness signal for
 	// report badges: user messages land on marks, not events, so the count
 	// alone misses exactly the follow-ups that matter most.

--- a/internal/model/schema_test.go
+++ b/internal/model/schema_test.go
@@ -1,0 +1,238 @@
+package model
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/santhosh-tekuri/jsonschema/v6"
+)
+
+// validateAgainstSchema marshals v to JSON, compiles the named schema file,
+// and reports a fatal error if the JSON does not validate.
+func validateAgainstSchema(t *testing.T, schemaPath string, v any) {
+	t.Helper()
+
+	document, err := json.Marshal(v)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var value any
+	if err := json.Unmarshal(document, &value); err != nil {
+		t.Fatal(err)
+	}
+
+	compiler := jsonschema.NewCompiler()
+
+	schema, err := compiler.Compile(schemaPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := schema.Validate(value); err != nil {
+		t.Fatalf("%s schema validation failed: %v\nJSON: %s", schemaPath, err, document)
+	}
+}
+
+func TestTraceSchemaAcceptsRepresentativeTrace(t *testing.T) {
+	tr := Trace{
+		Version: 1,
+		Session: TraceSession{
+			ID:         "test-session",
+			Harness:    "crush",
+			Model:      "claude-sonnet-4",
+			EventCount: 3,
+		},
+		Events: []Event{
+			{
+				Seq:     1,
+				Tool:    "read",
+				Action:  "read",
+				Summary: "read main.go",
+				Targets: []Target{{Path: "main.go", Touch: "read"}},
+			},
+			{
+				Seq:     2,
+				Tool:    "edit",
+				Action:  "edit",
+				Summary: "edit utils.go",
+				Targets: []Target{{Path: "util.go", Touch: "edit"}},
+			},
+			{Seq: 3, Tool: "bash", Action: "exec", Summary: "go test", Targets: []Target{}},
+		},
+		Marks: []Mark{
+			{Seq: 1, Type: "user-message"},
+			{Seq: 2, Type: "thinking", Duration: 5},
+		},
+		Stats: Stats{
+			FilesInRepo:           10,
+			Fovea:                 3,
+			Parafovea:             2,
+			Edited:                1,
+			EventsBeforeFirstEdit: 1,
+			RegressionRate:        0.0,
+			ErrorRate:             0.33,
+			Actions:               ActionCounts{Read: 1, Edit: 1, Exec: 1, Other: 0},
+			Errors:                ActionCounts{},
+			Observability:         Observability{Reads: "exact", Errors: "estimated"},
+			ResultBytes:           1024,
+			UserTurns:             1,
+		},
+	}
+	validateAgainstSchema(t, "../../schema/trace.schema.json", tr)
+}
+
+func TestReportSchemaAcceptsRepresentativeReport(t *testing.T) {
+	rep := Report{
+		Version: 1,
+		Session: ReportSession{
+			ID:         "test-session",
+			Harness:    "crush",
+			Model:      "claude-sonnet-4",
+			EventCount: 10,
+			UserTurns:  2,
+		},
+		Judge: ReportJudge{
+			CLI:           "claude",
+			Model:         "claude-sonnet-4",
+			PromptVersion: 1,
+			GeneratedAt:   "2026-08-04T12:00:00Z",
+			InputDigest:   "abc123",
+		},
+		TaskSummary: "Fix a bug in the parser",
+		Dimensions: []ReportDimension{
+			{
+				Name:    DimensionExploration,
+				Verdict: VerdictGood,
+				Findings: []ReportFinding{
+					{Claim: "Explored the right files", Severity: SeverityInfo, EvidenceSeqs: []int{1, 2}},
+				},
+			},
+			{
+				Name:    DimensionScope,
+				Verdict: VerdictWarning,
+				Findings: []ReportFinding{
+					{Claim: "Edited an unrelated file", Severity: SeverityWarning, EvidenceSeqs: []int{5}},
+				},
+			},
+			{
+				Name:    DimensionWandering,
+				Verdict: VerdictGood,
+				Findings: []ReportFinding{
+					{Claim: "Stayed focused", Severity: SeverityInfo, EvidenceSeqs: []int{3}},
+				},
+			},
+			{
+				Name:    DimensionVerification,
+				Verdict: VerdictProblem,
+				Findings: []ReportFinding{
+					{Claim: "No verification step", Severity: SeverityProblem, EvidenceSeqs: []int{8}},
+				},
+			},
+		},
+		Narrative: "The agent explored well but skipped verification.",
+	}
+	validateAgainstSchema(t, "../../schema/report.schema.json", rep)
+}
+
+func TestReportSchemaAcceptsReportWithRubric(t *testing.T) {
+	rep := Report{
+		Version: 1,
+		Session: ReportSession{
+			ID:         "rubric-test",
+			Harness:    "codex",
+			EventCount: 5,
+		},
+		Judge: ReportJudge{
+			CLI:                 "codex",
+			PromptVersion:       1,
+			RubricPromptVersion: 1,
+			GeneratedAt:         "2026-08-04T12:00:00Z",
+			InputDigest:         "def456",
+		},
+		TaskSummary: "Add a feature",
+		Dimensions: []ReportDimension{
+			{
+				Name:    DimensionExploration,
+				Verdict: VerdictGood,
+				Findings: []ReportFinding{
+					{Claim: "good", Severity: SeverityInfo, EvidenceSeqs: []int{1}},
+				},
+			},
+			{
+				Name:     DimensionScope,
+				Verdict:  VerdictGood,
+				Findings: []ReportFinding{{Claim: "good", Severity: SeverityInfo, EvidenceSeqs: []int{1}}},
+			},
+			{
+				Name:     DimensionWandering,
+				Verdict:  VerdictGood,
+				Findings: []ReportFinding{{Claim: "good", Severity: SeverityInfo, EvidenceSeqs: []int{1}}},
+			},
+			{
+				Name:     DimensionVerification,
+				Verdict:  VerdictGood,
+				Findings: []ReportFinding{{Claim: "good", Severity: SeverityInfo, EvidenceSeqs: []int{1}}},
+			},
+		},
+		Rubric: &Rubric{
+			Status: RubricStatusScored,
+			Tasks: []RubricTask{
+				{
+					Title:              "Add the feature",
+					AnchorUserMessages: []int{1},
+					Criteria: []RubricCriterion{
+						{
+							ID:       "crit-1",
+							Title:    "Implementation correct",
+							Coverage: CoverageSufficient,
+							Verdict:  VerdictGood,
+							Findings: []ReportFinding{
+								{Claim: "correct", Severity: SeverityInfo, EvidenceSeqs: []int{1}},
+							},
+						},
+					},
+				},
+			},
+		},
+		Narrative: "Done.",
+	}
+	validateAgainstSchema(t, "../../schema/report.schema.json", rep)
+}
+
+func TestCityMapSchemaAcceptsRepresentativeCityMap(t *testing.T) {
+	cm := CityMap{
+		Version: 1,
+		Repo: RepoMeta{
+			Root:        "/tmp/repo",
+			Commit:      "abc123",
+			Dirty:       false,
+			GeneratedAt: "2026-08-04T12:00:00Z",
+		},
+		Files: []CityFile{
+			{
+				ID:    0,
+				Path:  "main.go",
+				Dir:   "",
+				Lines: 100,
+				Bytes: 2048,
+				Lang:  "go",
+				Rect:  Rect{X: 0, Z: 0, W: 0.5, D: 0.5},
+			},
+			{
+				ID:    1,
+				Path:  "util.go",
+				Dir:   "",
+				Lines: 50,
+				Bytes: 1024,
+				Lang:  "go",
+				Rect:  Rect{X: 0.5, Z: 0, W: 0.5, D: 0.5},
+			},
+		},
+		Dirs: []CityDir{
+			{Path: "pkg", Depth: 1, Rect: Rect{X: 0, Z: 0, W: 1, D: 1}, FileCount: 2, Lines: 150},
+		},
+		Layout: LayoutMeta{Algorithm: "squarified", Weight: "lines"},
+	}
+	validateAgainstSchema(t, "../../schema/citymap.schema.json", cm)
+}

--- a/internal/model/stats.go
+++ b/internal/model/stats.go
@@ -1,10 +1,24 @@
 package model
 
-// ComputeStats derives session facts from a parsed trace. errorSignal is the
-// adapter's grade for its own error detection (ObservabilityExact when the
-// source log flags failures structurally, ObservabilityEstimated when they
-// are inferred from output text); an empty value falls back to estimated.
-func ComputeStats(trace *Trace, filesInRepo int, errorSignal string) Stats {
+// ObservabilitySignals carries adapter-supplied observability grades into
+// ComputeStats, preventing positional-parameter explosion as more signals
+// are added. Each field overrides the derived grade when non-empty.
+type ObservabilitySignals struct {
+	// Errors is the adapter's grade for its own error detection
+	// (ObservabilityExact when the source log flags failures structurally,
+	// ObservabilityEstimated when they are inferred from output text).
+	// Empty falls back to estimated.
+	Errors string
+	// Reads overrides the reads grade when non-empty (used by adapters
+	// that have a structural read_files table); empty falls back to
+	// deriving from weak target flags.
+	Reads string
+}
+
+// ComputeStats derives session facts from a parsed trace. The signals
+// parameter carries adapter-supplied observability grades; empty fields
+// are derived from the trace data.
+func ComputeStats(trace *Trace, filesInRepo int, signals ObservabilitySignals) Stats {
 	state := map[string]string{}
 	lastReadVersion := map[string]int{}
 	editVersion := map[string]int{}
@@ -100,24 +114,43 @@ func ComputeStats(trace *Trace, filesInRepo int, errorSignal string) Stats {
 	if len(trace.Events) > 0 {
 		stats.ErrorRate = float64(errors) / float64(len(trace.Events))
 	}
-	// Weak read targets are inferred from command text, so any of them in the
-	// mix downgrades the re-read rate; no reads at all leaves it undefined.
-	switch {
-	case readEvents == 0:
-		stats.Observability.Reads = ObservabilityUnavailable
-	case weakReads == 0:
-		stats.Observability.Reads = ObservabilityExact
-	default:
-		stats.Observability.Reads = ObservabilityEstimated
+	// The reads grade: prefer the adapter-supplied signal (structural
+	// truth from a read_files table); fall back to deriving from weak
+	// target flags when the adapter did not supply one. Unrecognized
+	// override values are treated as absent so adapter bugs can never
+	// leak an invalid grade into stats or the exported schema.
+	readsSignal := signals.Reads
+	if !knownObservabilityGrade(readsSignal) {
+		switch {
+		case readEvents == 0:
+			readsSignal = ObservabilityUnavailable
+		case weakReads == 0:
+			readsSignal = ObservabilityExact
+		default:
+			readsSignal = ObservabilityEstimated
+		}
 	}
-	if errorSignal == "" {
+	stats.Observability.Reads = readsSignal
+	errorSignal := signals.Errors
+	if !knownObservabilityGrade(errorSignal) {
 		errorSignal = ObservabilityEstimated
 	}
+
 	if errorSignal == ObservabilityExact && unknownOutcomes {
 		errorSignal = ObservabilityEstimated
 	}
+
 	stats.Observability.Errors = errorSignal
 	return stats
+}
+
+func knownObservabilityGrade(v string) bool {
+	switch v {
+	case ObservabilityExact, ObservabilityEstimated, ObservabilityUnavailable:
+		return true
+	default:
+		return false
+	}
 }
 
 func countAction(counts *ActionCounts, action string) {

--- a/internal/model/stats_test.go
+++ b/internal/model/stats_test.go
@@ -22,23 +22,28 @@ func TestComputeStatsFactCounters(t *testing.T) {
 		},
 	}
 
-	stats := ComputeStats(trace, 10, ObservabilityExact)
+	stats := ComputeStats(trace, 10, ObservabilitySignals{Errors: ObservabilityExact})
 
 	if stats.Actions != (ActionCounts{Search: 1, Read: 1, Edit: 4, Exec: 1, Verify: 1}) {
 		t.Fatalf("actions = %#v", stats.Actions)
 	}
+
 	if stats.Errors != (ActionCounts{Edit: 1, Exec: 1}) {
 		t.Fatalf("errors = %#v", stats.Errors)
 	}
+
 	if stats.MaxEditsPerFile != 3 || stats.ChurnFiles != 1 {
 		t.Fatalf("maxEditsPerFile = %d, churnFiles = %d", stats.MaxEditsPerFile, stats.ChurnFiles)
 	}
+
 	if stats.UserTurns != 2 || stats.Compactions != 1 || stats.Subagents != 1 {
 		t.Fatalf("marks = %d/%d/%d", stats.UserTurns, stats.Compactions, stats.Subagents)
 	}
+
 	if stats.ResultBytes != 30 {
 		t.Fatalf("resultBytes = %d", stats.ResultBytes)
 	}
+
 	if stats.EditsAfterLastVerify != 1 {
 		t.Fatalf("editsAfterLastVerify = %d", stats.EditsAfterLastVerify)
 	}
@@ -51,7 +56,11 @@ func TestComputeStatsEditsAfterLastVerifyWithoutVerify(t *testing.T) {
 			{Seq: 1, Action: "edit", Targets: []Target{{Path: "b.go", Touch: "edit"}}},
 		},
 	}
-	if stats := ComputeStats(trace, 0, ObservabilityExact); stats.EditsAfterLastVerify != 2 {
+	if stats := ComputeStats(
+		trace,
+		0,
+		ObservabilitySignals{Errors: ObservabilityExact},
+	); stats.EditsAfterLastVerify != 2 {
 		t.Fatalf("editsAfterLastVerify = %d", stats.EditsAfterLastVerify)
 	}
 }
@@ -71,18 +80,53 @@ func TestComputeStatsObservability(t *testing.T) {
 		wantErrors  string
 	}{
 		{"strong reads are exact", []Event{strongRead}, ObservabilityExact, ObservabilityExact, ObservabilityExact},
-		{"any weak read downgrades", []Event{strongRead, weakRead}, ObservabilityExact, ObservabilityEstimated, ObservabilityExact},
-		{"unknown outcome downgrades exact errors", []Event{strongRead, pending}, ObservabilityExact, ObservabilityExact, ObservabilityEstimated},
-		{"legacy failure remains known", []Event{legacyFailure}, ObservabilityExact, ObservabilityUnavailable, ObservabilityExact},
-		{"no reads is unavailable", []Event{hitOnly}, ObservabilityEstimated, ObservabilityUnavailable, ObservabilityEstimated},
-		{"empty error signal falls back to estimated", []Event{strongRead}, "", ObservabilityExact, ObservabilityEstimated},
+		{
+			"any weak read downgrades",
+			[]Event{strongRead, weakRead},
+			ObservabilityExact,
+			ObservabilityEstimated,
+			ObservabilityExact,
+		},
+		{
+			"unknown outcome downgrades exact errors",
+			[]Event{strongRead, pending},
+			ObservabilityExact,
+			ObservabilityExact,
+			ObservabilityEstimated,
+		},
+		{
+			"legacy failure remains known",
+			[]Event{legacyFailure},
+			ObservabilityExact,
+			ObservabilityUnavailable,
+			ObservabilityExact,
+		},
+		{
+			"no reads is unavailable",
+			[]Event{hitOnly},
+			ObservabilityEstimated,
+			ObservabilityUnavailable,
+			ObservabilityEstimated,
+		},
+		{
+			"empty error signal falls back to estimated",
+			[]Event{strongRead},
+			"",
+			ObservabilityExact,
+			ObservabilityEstimated,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			stats := ComputeStats(&Trace{Events: tt.events}, 0, tt.errorSignal)
+			stats := ComputeStats(&Trace{Events: tt.events}, 0, ObservabilitySignals{Errors: tt.errorSignal})
 			if stats.Observability.Reads != tt.wantReads || stats.Observability.Errors != tt.wantErrors {
-				t.Fatalf("observability = %#v, want reads %q errors %q", stats.Observability, tt.wantReads, tt.wantErrors)
+				t.Fatalf(
+					"observability = %#v, want reads %q errors %q",
+					stats.Observability,
+					tt.wantReads,
+					tt.wantErrors,
+				)
 			}
 		})
 	}

--- a/internal/model/trace_schema_parity_test.go
+++ b/internal/model/trace_schema_parity_test.go
@@ -1,0 +1,110 @@
+//nolint:testpackage // Match the rest of the model test files (agent_schema_test, schema_test, etc).
+package model
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestTraceSchemaParityWithTypesScript walks the trace JSON schema
+// and asserts that every required event property has a counterpart
+// in the frontend's TraceEvent declaration. The two evolve
+// independently — Go changes via go.mod + regen, TS changes via
+// web/package.json — so a parity test catches drift before a
+// backend change ships without the frontend matching.
+//
+// The check is deliberately one-way: schema properties must exist
+// in TS. TS-only properties are allowed (the frontend can carry
+// view-layer fields the backend never emits) but the schema is the
+// source of truth for what the API returns.
+func TestTraceSchemaParityWithTypesScript(t *testing.T) {
+	t.Parallel()
+
+	repoRoot := filepath.Join("..", "..")
+	schemaPath := filepath.Join(repoRoot, "schema", "trace.schema.json")
+	typesPath := filepath.Join(repoRoot, "web", "src", "types.ts")
+
+	schemaBytes, err := os.ReadFile(schemaPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", schemaPath, err)
+	}
+
+	typesBytes, err := os.ReadFile(typesPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", typesPath, err)
+	}
+
+	var schema struct {
+		Properties map[string]struct {
+			Properties map[string]struct{} `json:"properties"`
+			Items      struct {
+				Properties map[string]struct{} `json:"properties"`
+				Required   []string            `json:"required"`
+			} `json:"items"`
+		} `json:"properties"`
+	}
+	if err := json.Unmarshal(schemaBytes, &schema); err != nil {
+		t.Fatalf("parse schema: %v", err)
+	}
+
+	events := schema.Properties["events"].Items
+
+	var missing []string
+
+	for _, name := range events.Required {
+		if _, ok := lookupTSField(typesBytes, "TraceEvent", name); !ok {
+			missing = append(missing, name)
+		}
+	}
+
+	if len(missing) > 0 {
+		t.Fatalf("trace.schema.json event fields missing from web/src/types.ts TraceEvent: %v", missing)
+	}
+}
+
+// lookupTSField scans a TypeScript file for an interface field, matching
+// the camelCase name inside `interface <ownerName> { ... }` (with an
+// optional `export ` prefix). The scan is line-based: it returns true
+// when the field name appears at the start of a line that has been
+// recognised as a property declaration.
+func lookupTSField(source []byte, interfaceName, field string) (struct{}, bool) {
+	var (
+		depth   int
+		inBlock bool
+		lines   = strings.Split(string(source), "\n")
+	)
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if !inBlock {
+			if strings.HasPrefix(trimmed, "interface "+interfaceName) ||
+				strings.HasPrefix(trimmed, "export interface "+interfaceName) {
+				inBlock = true
+			}
+
+			continue
+		}
+
+		// crude brace tracking: each '{' adds, each '}' subtracts
+		for _, r := range trimmed {
+			switch r {
+			case '{':
+				depth++
+			case '}':
+				depth--
+			}
+		}
+
+		if depth <= 0 && strings.Contains(trimmed, "}") {
+			return struct{}{}, false
+		}
+
+		if strings.HasPrefix(trimmed, field+":") || strings.HasPrefix(trimmed, field+"?:") {
+			return struct{}{}, true
+		}
+	}
+
+	return struct{}{}, false
+}

--- a/internal/model/trace_schema_test.go
+++ b/internal/model/trace_schema_test.go
@@ -42,25 +42,31 @@ func TestTraceSchemaAcceptsOutcomeCertainty(t *testing.T) {
 			},
 		},
 		Marks: []Mark{},
-		Stats: ComputeStats(&Trace{}, 0, ObservabilityEstimated),
+		Stats: ComputeStats(&Trace{}, 0, ObservabilitySignals{}),
 	}
+
 	document, err := json.Marshal(trace)
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	var value any
 	if err := json.Unmarshal(document, &value); err != nil {
 		t.Fatal(err)
 	}
+
 	events := value.(map[string]any)["events"].([]any)
 	if _, found := events[2].(map[string]any)["outcomeKnown"]; found {
 		t.Fatal("unknown outcome serialized outcomeKnown")
 	}
+
 	compiler := jsonschema.NewCompiler()
+
 	schema, err := compiler.Compile("../../schema/trace.schema.json")
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	if err := schema.Validate(value); err != nil {
 		t.Fatalf("trace with outcome certainty violates schema: %v\n%s", err, document)
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -886,7 +886,7 @@ func (s *Server) loadTraceAndMap(meta model.SessionMeta) (*model.Trace, *model.C
 	}
 	// Recompute with the citymap's file count, carrying over the adapter's
 	// grade for its error signal — the recount cannot re-derive it.
-	trace.Stats = model.ComputeStats(trace, repoFileCount(city), trace.Stats.Observability.Errors)
+	trace.Stats = model.ComputeStats(trace, repoFileCount(city), model.ObservabilitySignals{Errors: trace.Stats.Observability.Errors})
 	return trace, city, nil
 }
 
@@ -1030,7 +1030,7 @@ func traceAgainstCity(trace *model.Trace, city *model.CityMap) *model.Trace {
 	}
 	clone.Marks = append([]model.Mark{}, trace.Marks...)
 	assignFileIDs(&clone, city)
-	clone.Stats = model.ComputeStats(&clone, repoFileCount(city), trace.Stats.Observability.Errors)
+	clone.Stats = model.ComputeStats(&clone, repoFileCount(city), model.ObservabilitySignals{Errors: trace.Stats.Observability.Errors})
 	return &clone
 }
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1217,7 +1217,7 @@ func newAgentAPIServer(t *testing.T) (*Server, *agentAPISource) {
 			Session: model.TraceSession{ID: id, Harness: "agent-api", Cwd: meta.Cwd, Path: meta.Path, EventCount: len(events)},
 			Events:  events,
 			Marks:   []model.Mark{},
-			Stats:   model.ComputeStats(&model.Trace{Events: events}, 1, model.ObservabilityExact),
+			Stats:   model.ComputeStats(&model.Trace{Events: events}, 1, model.ObservabilitySignals{Errors: model.ObservabilityExact}),
 		}
 	}
 	zeroMeta := metas[filepath.Clean(paths["child-zero"])]
@@ -1226,7 +1226,7 @@ func newAgentAPIServer(t *testing.T) (*Server, *agentAPISource) {
 		Session: model.TraceSession{ID: "child-zero", Harness: "agent-api", Cwd: zeroMeta.Cwd, Path: zeroMeta.Path, EventCount: 0},
 		Events:  []model.Event{},
 		Marks:   []model.Mark{},
-		Stats:   model.ComputeStats(&model.Trace{Events: []model.Event{}}, 1, model.ObservabilityExact),
+		Stats:   model.ComputeStats(&model.Trace{Events: []model.Event{}}, 1, model.ObservabilitySignals{Errors: model.ObservabilityExact}),
 	}
 	graphs := map[string]*model.AgentGraph{
 		"root-a": {

--- a/internal/textutil/truncate.go
+++ b/internal/textutil/truncate.go
@@ -18,6 +18,7 @@ func TruncateRunes(text string, limit int, marker string) string {
 		if utf8.ValidString(text) {
 			return text
 		}
+
 		return string(runes)
 	}
 
@@ -25,6 +26,8 @@ func TruncateRunes(text string, limit int, marker string) string {
 	if len(markerRunes) > limit {
 		markerRunes = markerRunes[:limit]
 	}
+
 	contentLimit := limit - len(markerRunes)
+
 	return string(runes[:contentLimit]) + string(markerRunes)
 }

--- a/internal/textutil/truncate_test.go
+++ b/internal/textutil/truncate_test.go
@@ -28,9 +28,11 @@ func TestTruncateRunes(t *testing.T) {
 			if got != tt.want {
 				t.Fatalf("TruncateRunes() = %q, want %q", got, tt.want)
 			}
+
 			if !utf8.ValidString(got) {
 				t.Fatalf("TruncateRunes() returned invalid UTF-8: %q", got)
 			}
+
 			if gotRunes := len([]rune(got)); gotRunes > tt.limit {
 				t.Fatalf("TruncateRunes() returned %d runes, limit %d", gotRunes, tt.limit)
 			}

--- a/schema/trace.schema.json
+++ b/schema/trace.schema.json
@@ -13,6 +13,7 @@
         "id": { "type": "string" },
         "harness": { "type": "string" },
         "model": { "type": "string" },
+        "provider": { "type": "string" },
         "title": { "type": "string" },
         "cwd": { "type": "string" },
         "commit": { "type": "string" },
@@ -52,7 +53,8 @@
           "resultBytes": { "type": "integer", "minimum": 0 },
           "isError": { "type": "boolean" },
           "outcomeKnown": { "type": "boolean" },
-          "summary": { "type": "string" }
+          "summary": { "type": "string" },
+          "providerExecuted": { "type": "boolean" }
         },
         "additionalProperties": false
       }
@@ -64,10 +66,15 @@
         "required": ["seq", "type"],
         "properties": {
           "seq": { "type": "integer", "minimum": 0 },
-          "type": { "enum": ["compaction", "user-message", "subagent"] },
+          "type": { "enum": ["compaction", "user-message", "subagent", "thinking", "finish-reason", "model-switch"] },
           "note": {
             "type": "string",
             "description": "Free-form context for the mark: user-message marks carry the message text truncated to 2000 runes; subagent marks carry the tool name"
+          },
+          "duration": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Wall-clock duration in seconds from the message's created_at to finished_at; present on thinking and finish-reason marks when the harness records it"
           }
         },
         "additionalProperties": false


### PR DESCRIPTION
## Why

`ComputeStats` currently takes a positional error-signal string, and reads observability has no explicit channel at all — adapters that know their read evidence had to bolt it on post-hoc. Two more evidence gaps show up with newer harnesses: tools executed provider-side (computer use) are indistinguishable from local ones, and sub-agent sessions have no metadata home in the shared model.

## What changed

- `ComputeStats` gains an `ObservabilitySignals` struct parameter (errors + reads), replacing the positional string — mechanical call-site updates across `claudecode`, `codex`, `pi`, `server`, and their tests.
- `Event.ProviderExecuted` marks provider-side tool execution.
- `SessionMeta` gains agent-session metadata fields.
- `trace.schema.json` learns the `thinking` / `finish-reason` mark types and mark `duration`; a schema-parity test keeps the TS mirror and the JSON contract in lockstep.
- Model fuzz tests for the stats/schema surface.

No behavior change for existing traces: the signals default to the previous derived behavior when unset.

## Series

Part **1/3** — lands the shared contract first so the consumer PRs review in isolation:
- 2/3 `adapter-shared-contract` — shared helpers + `ToolCallID` pairing contract
- 3/3 `crush-adapter-core` — Crush session adapter (exercises all of the above)

## Validation

- `go build ./...`
- `go test -count=1 ./...` — green at the branch tip
- Schema parity test enforces `trace.schema.json` ↔ frontend types

Context: the library-extraction discussion in #15 suggested reuse-friendly, published dependencies are welcome here; this PR keeps the model layer dependency-free.

💘 Generated with Crush